### PR TITLE
(SIMP-4053) Pin gitlab-ce version to fix broken tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,6 +193,19 @@ el7-acceptance:
   script:
     - bundle exec rake beaker:suites[default,centos-7-x64]
 
+el7-acceptance-latest-gitlab:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
+    TEST_GITLAB_CE_VERSION: 'latest'
+  script:
+    - bundle exec rake beaker:suites[default,centos-7-x64]
+   allow_failure: true
+
 el6-acceptance:
   stage: acceptance
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,10 +20,17 @@
       - '.vendor'
       - 'vendor'
 
-.setup_bundler_env: &setup_bundler_env
+.setup_env: &setup_env
   before_script:
     - '(find .vendor | wc -l) || :'
-    - gem install bundler --no-rdoc --no-ri
+    - bundle || gem install bundler --no-rdoc --no-ri
+    - rm -f Gemfile.lock
+    - rm -rf pkg/
+    - bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}"
+
+.setup_env_beaker: &setup_env_beaker
+  before_script:
+    - '(find .vendor | wc -l) || :'
     - rm -f Gemfile.lock
     - rm -rf pkg/
     - bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}"
@@ -60,7 +67,7 @@ pup4.7-validation:
   variables:
     PUPPET_VERSION: '~> 4.7.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *validation_checks
 
 pup4.7-unit:
@@ -71,7 +78,7 @@ pup4.7-unit:
   variables:
     PUPPET_VERSION: '~> 4.7.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *spec_tests
 
 
@@ -85,7 +92,7 @@ pup4.8-validation:
   variables:
     PUPPET_VERSION: '~> 4.8.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *validation_checks
 
 pup4.8-unit:
@@ -96,7 +103,7 @@ pup4.8-unit:
   variables:
     PUPPET_VERSION: '~> 4.8.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *spec_tests
 
 
@@ -111,7 +118,7 @@ pup4.10-validation:
   variables:
     PUPPET_VERSION: '~> 4.10.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *validation_checks
 
 pup4.10-unit:
@@ -122,7 +129,7 @@ pup4.10-unit:
   variables:
     PUPPET_VERSION: '~> 4.10.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *spec_tests
 
 
@@ -137,7 +144,7 @@ pup5.3-validation:
   variables:
     PUPPET_VERSION: '~> 5.3.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *validation_checks
 
 pup5.3-unit:
@@ -148,8 +155,9 @@ pup5.3-unit:
   variables:
     PUPPET_VERSION: '~> 5.3.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *spec_tests
+  allow_failure: true
 
 
 # Keep an eye on the latest puppet 5
@@ -162,7 +170,7 @@ pup5.latest-validation:
   variables:
     PUPPET_VERSION: '~> 5.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *validation_checks
   allow_failure: true
 
@@ -174,7 +182,7 @@ pup5.latest-unit:
   variables:
     PUPPET_VERSION: '~> 5.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *spec_tests
   allow_failure: true
 
@@ -187,7 +195,7 @@ el7-acceptance:
   tags:
     - beaker
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env_beaker
   variables:
     PUPPET_VERSION: '4.10'
   script:
@@ -198,20 +206,20 @@ el7-acceptance-latest-gitlab:
   tags:
     - beaker
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env_beaker
   variables:
     PUPPET_VERSION: '4.10'
     TEST_GITLAB_CE_VERSION: 'latest'
   script:
     - bundle exec rake beaker:suites[default,centos-7-x64]
-   allow_failure: true
+  allow_failure: true
 
 el6-acceptance:
   stage: acceptance
   tags:
     - beaker
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env_beaker
   variables:
     PUPPET_VERSION: '4.10'
   script:

--- a/README.md
+++ b/README.md
@@ -315,6 +315,16 @@ bundle exec rake beaker:suites
 Please refer to the [SIMP Beaker Helpers documentation](https://github.com/simp/rubygem-simp-beaker-helpers/blob/master/README.md)
 for more information.
 
+#### Environment variable `TEST_GITLAB_CE_VERSION`
+
+`TEST_GITLAB_CE_VERSION` is an environment variable that can be used
+to specify the version of gitlab-ce to use in the acceptance tests.
+When set, it must either a version string for a specific gitlab-ce
+package version or 'latest' to indicate the latest available version.
+
+```shell
+TEST_GITLAB_CE_VERSION=latest bundle exec rake beaker:suites
+```
 #### Environment variable `TRUSTED_NETS`
 
 `TRUSTED_NETS` is an environment variable that may contain a comma-delimited

--- a/spec/acceptance/suites/default/00_pki_spec.rb
+++ b/spec/acceptance/suites/default/00_pki_spec.rb
@@ -21,6 +21,7 @@ describe 'simp_gitlab pki tls with firewall' do
                         ],
         pki                     => true,
         app_pki_external_source => '/etc/pki/simp-testing/pki',
+        gitlab_options => {'package_ensure' => '#{gitlab_ce_version}' },
       }
     EOS
   end
@@ -56,6 +57,7 @@ describe 'simp_gitlab pki tls with firewall' do
         "class {'iptables': enable => false }"
       )
       apply_manifest_on(gitlab_server, no_firewall_manifest, catch_changes: true)
+      on(gitlab_server, 'rpm -q gitlab-ce')
     end
 
     it_behaves_like(
@@ -75,7 +77,6 @@ describe 'simp_gitlab pki tls with firewall' do
       expect(results['values']['gitlab_user']).to eq 'git'
     end
   end
-
 
   context 'with PKI + firewall + custom port 777' do
     let(:new_lines) do

--- a/spec/acceptance/suites/default/01_no_pki_spec.rb
+++ b/spec/acceptance/suites/default/01_no_pki_spec.rb
@@ -21,6 +21,7 @@ describe 'simp_gitlab class' do
                         ],
         pki      => false,
         firewall => true,
+        gitlab_options => {'package_ensure' => '#{gitlab_ce_version}' },
       }
     EOS
   end

--- a/spec/acceptance/suites/default/10_ldaps_spec.rb
+++ b/spec/acceptance/suites/default/10_ldaps_spec.rb
@@ -41,6 +41,7 @@ describe 'simp_gitlab using ldap' do
         firewall => true,
         ldap     => true,
         app_pki_external_source => '/etc/pki/simp-testing/pki',
+        gitlab_options => {'package_ensure' => '#{gitlab_ce_version}' },
       }
     EOS
   end

--- a/spec/acceptance/support/helpers/simp_gitlab_beaker_helpers.rb
+++ b/spec/acceptance/support/helpers/simp_gitlab_beaker_helpers.rb
@@ -1,6 +1,19 @@
 module SimpGitlabBeakerHelpers
   # memoized variables to share across examples
   module SutVariables
+    def gitlab_ce_version
+      unless @gitlab_ce_version
+        if ENV['TEST_GITLAB_CE_VERSION'] and !ENV['TEST_GITLAB_CE_VERSION'].strip.empty?
+          # explicit version or latest
+          @gitlab_ce_version = ENV['TEST_GITLAB_CE_VERSION']
+        else
+        # NOTE:  Known to fail with 10.5.2
+          @gitlab_ce_version = '10.5.1'
+        end
+      end
+      @gitlab_ce_version
+    end
+
     def gitlab_server
       @gitlab_server ||= only_host_with_role( hosts, 'server' )
     end


### PR DESCRIPTION
Pin gitlab-ce version to the latest version that works in the
acceptance tests, but allow any version to be specified with
an environment variable.

SIMP-4053 #comment fix tests broken by latest gitlab-ce