### PR TITLE
(SIMP-4590) r10k deploy not working after 6.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Mar 28 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 0.3.0
+- Updated README to note that authorized key files need to be copied
+  when upgrading from version 0.2.0.
+
 * Wed Feb 28 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 0.3.0
 - Drop support for CentOS 6 in order to cleanly solve an intermittent
   problem in which the GitLab local user's authorized keys lock file

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Wed Mar 28 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 0.3.0
+* Wed Mar 28 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 0.3.1
 - Updated README to note that authorized key files need to be copied
   when upgrading from version 0.2.0.
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ management are disabled from the module, and that the `gitlab-ce` or
 `gitlab-ee` package is installed.  Be sure that the `$::simp_gitlab::edition`
 parameter is set to the correct edition.
 
+### Upgrade to 0.3.0
+
+Upgrading from simp_gitlab 0.2.0 to 0.3.0 requires you to copy the authorized key file
+from /etc/ssh/local_key/git to /var/opt/gitlab/.ssh/authorized_keys. Alternately
+you can re-add your deployment keys in the gitlab interface.
+See the CHANGELOG entries for version 0.3.0 for more details.
+
 ### Beginning with simp_gitlab
 
 The most basic GitLab usage within a SIMP-managed infrastructure where all

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ parameter is set to the correct edition.
 ### Upgrade to 0.3.0
 
 Upgrading from simp_gitlab 0.2.0 to 0.3.0 requires you to copy the authorized key file
-from /etc/ssh/local_key/git to /var/opt/gitlab/.ssh/authorized_keys. Alternately
+from /etc/ssh/local_keys/git to /var/opt/gitlab/.ssh/authorized_keys. Alternately
 you can re-add your deployment keys in the gitlab interface.
 See the CHANGELOG entries for version 0.3.0 for more details.
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ parameter is set to the correct edition.
 ### Upgrade to 0.3.0
 
 Upgrading from simp_gitlab 0.2.0 to 0.3.0 requires you to copy the authorized key file
-from /etc/ssh/local_keys/git to /var/opt/gitlab/.ssh/authorized_keys. Alternately
+from `/etc/ssh/local_keys/git` to `/var/opt/gitlab/.ssh/authorized_keys`. Alternately
 you can re-add your deployment keys in the gitlab interface.
 See the CHANGELOG entries for version 0.3.0 for more details.
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_gitlab",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "SIMP Team",
   "summary": "SIMP profiles for GitLab",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Updated readme to note that location of authorized key file has moved
  and you need to copy it.

SIMP-4590 #close