### PR TITLE
(SIMP-5028) Disable usage ping by default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Jul 13 2018 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.3.3
+- Disable usage ping
+
 * Thu Jun 14 2018 Nick Miller <nick.miller@onyxpoint.com> - 0.3.2
 - Update systemd fixtures and CI assets
 

--- a/functions/omnibus_config/gitlab_rails.pp
+++ b/functions/omnibus_config/gitlab_rails.pp
@@ -1,7 +1,16 @@
-# Compile a hash of settings for the gitlab module's `gitlab_rails` parameter, using SIMP settings
-# @return Hash of settings for the 'gitlab::gitlab_rails' parameter
+# Compile a hash of settings for the gitlab module's `gitlab_rails` parameter,
+# using SIMP settings
+#
+# @return Hash of settings for the 'gitlab::gitlab_rails' # parameter
 function simp_gitlab::omnibus_config::gitlab_rails() {
 
+  $options = {
+    'usage_ping_enabled' => false,
+  }
+
+  # --------------------------------------------------------------------
+  # Construct the 'dap_servers' Hash
+  # --------------------------------------------------------------------
   $_servers = hash($simp_gitlab::ldap_uri.map |$server| {
 
     # We should also capture a port if it is specified at end of the URL, but
@@ -48,13 +57,16 @@ function simp_gitlab::omnibus_config::gitlab_rails() {
     ]
   })
 
-  if $::simp_gitlab::ldap {
-    {
+  $ldap_options = $::simp_gitlab::ldap ? {
+    true    => {
       'ldap_enabled' => true,
       'ldap_servers' => $_servers,
-    }
-  } else {
-    {}
+    },
+    default =>  {},
   }
+  # --------------------------------------------------------------------
+
+  deep_merge( $options, $ldap_options )
+
 }
 

--- a/functions/omnibus_config/gitlab_rails.pp
+++ b/functions/omnibus_config/gitlab_rails.pp
@@ -9,7 +9,7 @@ function simp_gitlab::omnibus_config::gitlab_rails() {
   }
 
   # --------------------------------------------------------------------
-  # Construct the 'dap_servers' Hash
+  # Construct the 'ldap_servers' Hash
   # --------------------------------------------------------------------
   $_servers = hash($simp_gitlab::ldap_uri.map |$server| {
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_gitlab",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "author": "SIMP Team",
   "summary": "SIMP profiles for GitLab",
   "license": "Apache-2.0",


### PR DESCRIPTION
By default, every installation of GitLab sends a weekly report to GitLab
Inc, which contains usage details and the FQDN of the system. This
feature is opt-out, not opt-in.

This patch disables the update ping by default as an OPSEC safeguard,
consistent with NIST 800.53 rev 4 controls AC-20(1) and SC-38.

SIMP-5067 #close
SIMP-5028 #close