### PR TITLE
(SIMP-5297) updated $app_pki_external_source type

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -144,7 +144,7 @@ el7-acceptance:
   <<: *cache_bundler
   <<: *setup_env_beaker
   variables:
-    PUPPET_VERSION: '4.10'
+    PUPPET_VERSION: '~> 4.10.0'
   script:
     - bundle exec rake spec_clean
     - bundle exec rake beaker:suites[default,centos-7-x64]
@@ -156,7 +156,7 @@ el7-acceptance-latest-gitlab:
   <<: *cache_bundler
   <<: *setup_env_beaker
   variables:
-    PUPPET_VERSION: '4.10'
+    PUPPET_VERSION: '~> 4.10.0'
     TEST_GITLAB_CE_VERSION: 'latest'
   script:
     - bundle exec rake spec_clean
@@ -172,7 +172,7 @@ el7-acceptance-latest-gitlab:
 ###   <<: *cache_bundler
 ###   <<: *setup_bundler_env
 ###   variables:
-###     PUPPET_VERSION: '4.10'
+###     PUPPET_VERSION: '~> 4.10.0'
 ###     BEAKER_fips: 'yes'
 ###   script:
 ###     - bundle exec rake beaker:suites[default]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Sep 11 2018 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 0.3.4-0
+- Updated $app_pki_external_source to accept any string.  This matches the functionality
+  of pki::copy.
+
 * Fri Sep 07 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 0.3.4-0
 - Drop Hiera 4 support
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,8 +140,7 @@ class simp_gitlab (
   Optional[String[3]]    $ldap_group_base          = undef,
   Optional[String[1]]    $ldap_user_filter         = undef,
   Hash                   $gitlab_options           = {},
-
-  Stdlib::Absolutepath   $app_pki_external_source  = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
+  String                 $app_pki_external_source  = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
   Stdlib::Absolutepath   $app_pki_dir              = '/etc/pki/simp_apps/gitlab/x509',
   Stdlib::Absolutepath   $app_pki_key              = "${app_pki_dir}/private/${facts['fqdn']}.pem",
   Stdlib::Absolutepath   $app_pki_cert             = "${app_pki_dir}/public/${facts['fqdn']}.pub",


### PR DESCRIPTION
- Updated $app_pki_external_source to accept any string.  This matches the functionality
  of pki::copy.

SIMP-5296 #comment Updated simp_gitlab
SIMP-5297 #close