### PR TITLE
(SIMP-6170) simp_gitlab acceptance tests fail

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
 * Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.3.5-0
+- Added missing simp-pki dependency to metadata.json
+- Use ``generate_pem_hash_links`` option of pki_cert_sync to allow
+  the gitlab application to manage the certificate hash links.
+  ``gitlab reconfigure`` generates those hash links.
 - Update the upper bound of stdlib to < 6.0.0
 - Update a URL in the README.md
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -193,9 +193,11 @@ class simp_gitlab (
     }
 
     pki_cert_sync{ '/etc/gitlab/trusted-certs':
-      source => "${app_pki_dir}/cacerts",
-      purge  => true,
-      notify => Class['gitlab'],
+      source                  => "${app_pki_dir}/cacerts",
+      purge                   => true,
+      # ``gitlab reconfigure`` generates PEM hash links
+      generate_pem_hash_links => false,
+      notify                  => Class['gitlab'],
     }
 
     Pki::Copy['gitlab'] -> Pki_cert_sync['/etc/gitlab/trusted-certs']

--- a/metadata.json
+++ b/metadata.json
@@ -32,6 +32,10 @@
       "version_requirement": ">= 6.0.0 < 7.0.0"
     },
     {
+      "name": "simp/pki",
+      "version_requirement": ">= 6.1.0 < 7.0.0"
+    },
+    {
       "name": "simp/postfix",
       "version_requirement": ">= 5.0.0 < 6.0.0"
     },

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -49,6 +49,11 @@ describe 'simp_gitlab' do
             let(:params) {{
               :pki => true,
             }}
+            it { is_expected.to contain_pki__copy('gitlab') }
+            it { is_expected.to contain_pki_cert_sync('/etc/gitlab/trusted-certs').with( {
+              :purge                   => true,
+              :generate_pem_hash_links => false
+            } ) }
             it { is_expected.to contain_class('gitlab').with_external_port(443) }
             it { is_expected.to contain_class('gitlab').with_external_url(/^https/) }
             it 'should contain correct nginx settings' do


### PR DESCRIPTION
- Added missing simp-pki dependency to metadata.json
- Use ``generate_pem_hash_links`` option of pki_cert_sync to allow
  the gitlab application to manage the certificate hash links

SIMP-6170 #close