### PR TITLE
(SIMP-MAINT) Update min pki version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -41,7 +41,7 @@
     },
     {
       "name": "simp/pki",
-      "version_requirement": ">= 6.1.0 < 7.0.0"
+      "version_requirement": ">= 6.1.1 < 7.0.0"
     },
     {
       "name": "simp/postfix",


### PR DESCRIPTION
Update to minimum pupmod-simp-pki version that solves
the problem with temporary cacerts files being erroneously
parsed by a running gitlab application.  This update is
necessary to prevent broken links to the temporary files
in /etc/gitlab/trusted-certs.