### PR TITLE
(SIMP-8703) Disable Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
 # SIMP 6.4      5.5      2.4    TBD
-# PE 2018.1     5.5      2.4    2020-11 (LTS)
-# PE 2019.2     6.10     2.5    2019-08 (STS)
+# PE 2018.1     5.5      2.4    2021-01 (LTS)
+# PE 2019.2     6.18     2.5    2022-12 (LTS)
 #
 # https://puppet.com/docs/pe/2018.1/component_versions_in_recent_pe_releases.html
 # https://puppet.com/misc/puppet-enterprise-lifecycle
@@ -82,40 +82,47 @@ stages:
 
 jobs:
   include:
-    - stage: check
-      name: 'Syntax, style, and validation checks'
-      rvm: 2.4.9
-      env: PUPPET_VERSION="~> 5"
-      script:
-        - bundle exec rake check:dot_underscore
-        - bundle exec rake check:test_file
-        - bundle exec rake pkg:check_version
-        - bundle exec rake metadata_lint
-        - bundle exec rake pkg:compare_latest_tag
-        - bundle exec rake pkg:create_tag_changelog
-        - bundle exec rake lint
-        - bundle exec puppet module build
-
-    - stage: spec
-      rvm: 2.4.9
-      name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1)'
-      env: PUPPET_VERSION="~> 5.5.0"
-      script:
-        - bundle exec rake spec
-
-    - stage: spec
-      name: 'Puppet 5.x (Latest)'
-      rvm: 2.4.9
-      env: PUPPET_VERSION="~> 5.0"
-      script:
-        - bundle exec rake spec
-
-    - stage: spec
-      name: 'Puppet 6.10 (PE 2019.2)'
-      rvm: 2.5.7
-      env: PUPPET_VERSION="~> 6.10.0"
-      script:
-        - bundle exec rake spec
+    ###  Testing on Travis CI is indefinitely disabled
+    ###
+    ###  See:
+    ###    * https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
+    ###    * https://simp-project.atlassian.net/browse/SIMP-8703
+    ###
+    ###
+    ###    - stage: check
+    ###      name: 'Syntax, style, and validation checks'
+    ###      rvm: 2.4.9
+    ###      env: PUPPET_VERSION="~> 5"
+    ###      script:
+    ###        - bundle exec rake check:dot_underscore
+    ###        - bundle exec rake check:test_file
+    ###        - bundle exec rake pkg:check_version
+    ###        - bundle exec rake metadata_lint
+    ###        - bundle exec rake pkg:compare_latest_tag
+    ###        - bundle exec rake pkg:create_tag_changelog
+    ###        - bundle exec rake lint
+    ###        - bundle exec puppet module build
+    ###
+    ###    - stage: spec
+    ###      rvm: 2.4.9
+    ###      name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1)'
+    ###      env: PUPPET_VERSION="~> 5.5.0"
+    ###      script:
+    ###        - bundle exec rake spec
+    ###
+    ###    - stage: spec
+    ###      name: 'Puppet 5.x (Latest)'
+    ###      rvm: 2.4.9
+    ###      env: PUPPET_VERSION="~> 5.0"
+    ###      script:
+    ###        - bundle exec rake spec
+    ###
+    ###    - stage: spec
+    ###      name: 'Puppet 6.18 (PE 2019.2)'
+    ###      rvm: 2.5.7
+    ###      env: PUPPET_VERSION="~> 6.18.0"
+    ###      script:
+    ###        - bundle exec rake spec
 
     - stage: deploy
       rvm: 2.4.9


### PR DESCRIPTION
This patch disables ALL TESTS in modules' Travis CI pipelines.
Deployment and diagnostic stages have been left to support near-term
releases, however we will shortly migrate them elsewhere as well.

SIMP-8760 #close
[SIMP-8703] #comment Updated pupmod-simp-simp_gitlab

[SIMP-8703]: https://simp-project.atlassian.net/browse/SIMP-8703