### PR TITLE
(SIMP-8980) change_gitlab_root_password no longer works

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+* Thu Jan 07 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.6.1
+- Fixed a bug in which the change_gitlab_root_password script did
+  not work for GitLab versions that included Ruby 2.7.x (GitLab 13.6.0
+  and later).
+- Fixed a bug in which the change_gitlab_root_password script emitted
+  a 'WARNING: GitLab is not completely running' error message when
+  GitLab was fully running.
+
 * Sat Dec 19 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.6.1
 - Maintenance update for module assets
 

--- a/files/usr/local/sbin/change_gitlab_root_password
+++ b/files/usr/local/sbin/change_gitlab_root_password
@@ -8,17 +8,16 @@
 #
 # See https://docs.gitlab.com/ee/security/reset_user_password.html
 
-require 'expect'
 require 'fileutils'
 require 'optparse'
 require 'ostruct'
 require 'pty'
+require 'timeout'
 
 class GitlabRootPasswordChanger
 
   PROGRAM_NAME = File.basename(__FILE__)
-  DEFAULT_LOAD_TIMEOUT = 300  # this can take a long time
-  DEFAULT_CMD_TIMEOUT = 60    # this should take no time at all
+  DEFAULT_LOAD_TIMEOUT = 300  # loading gitlab-rails console can take a long time
   GITLAB_CTL_EXE = '/bin/gitlab-ctl'
   GITLAB_CONSOLE_EXE = '/bin/gitlab-rails'
   GITLAB_CONSOLE_COMMAND = "#{GITLAB_CONSOLE_EXE} console -e production"
@@ -27,22 +26,12 @@ class GitlabRootPasswordChanger
   def initialize
     @options = OpenStruct.new
     @options.debug = false
-    @options.cmd_timeout = DEFAULT_CMD_TIMEOUT
     @options.load_timeout = DEFAULT_LOAD_TIMEOUT
   end
 
-  # write out msg bytes to stdout, when @options.debug=true
-  #
-  # @param msg Either a String or an Array of Strings returned from the Regex
-  #   match in IO.expect()
+  # write msg to stdout, when @options.debug=true
   def debug(msg)
-    if @options.debug
-      if msg.is_a?(Array)
-        $stdout.write(msg[0])
-      else
-        $stdout.write(msg)
-      end
-    end
+    puts msg if @options.debug
   end
 
   # Parse and validate command line options and arguments
@@ -57,7 +46,8 @@ class GitlabRootPasswordChanger
         '--load-timeout [TIMEOUT_SECONDS]',
         Integer,
         'Timeout in seconds to wait for',
-        'gitlab-rails console to load.',
+        'gitlab-rails console to load',
+        'and process the change.',
         "Defaults to #{DEFAULT_LOAD_TIMEOUT} seconds."
       ) do |timeout|
         @options.load_timeout = timeout
@@ -101,59 +91,78 @@ class GitlabRootPasswordChanger
 
     verify_gitlab_running
 
-    debug("Loading gitlab-rails console (this can take some time)...\n")
-    debug("\n#{GITLAB_CONSOLE_COMMAND}\n")
+    # This logic block is fragile, but the best we can do due to limitations
+    # of the gitlab-rails console. Here are details for maintainers:
+    #
+    # - This logic was developed with gitlab-ce-13.7.1, but verified to also work
+    #   with gitlab-ce-12.3.0.
+    # - The gitlab-rails console uses IRB from the gitlab-provided Ruby.
+    #   - IRB will not exit with a bad error code when any command fails. This
+    #     means we have to scrape the command output to determine if the
+    #     commands succeed.
+    #   - When the input is piped to the gitlab-rails console, IRB determines
+    #     that the input is not from a TTY, and
+    #     * does not emit any prompts, which could have been customized via IRB
+    #       configuration
+    #     * does not prepend successful command results with '\t=> ' or a
+    #       configured string
+    #     * does not use ANSI cursor-moving command sequences that provide a more
+    #       IDE-like experience; a feature introduced with Ruby 2.7.0.
+    #
+    #     The suppression of the prompt and result prefix prevents this script from
+    #     failing due to user IRB configuration. The suppression of the ANSI
+    #     cursor-moving behavior allows easier support of different versions of
+    #     GitLab. (See NOTE below).
+    #   - Rails allows customization of the application that provides the console,
+    #     so it is possible (not necessarily likely) that the console could change
+    #     to a non-IRB implementation in a future GitLab release.
+    #
+    # NOTE:  Previous versions of this script used expect and parsed the
+    #   output based on the command prompt and results prefix for each individual
+    #   command in gitlab_ruby_commands below. This is no longer viable because of
+    #   the ANSI cursor-moving character sequences that Ruby 2.7's IRB uses when a
+    #   user enters a command. The cursor-moving sequences are used every time
+    #   a user enters a character. For example, the command prompt is modified to
+    #   contain a '?' character, when the input does not yet pass Ruby syntax
+    #   validation. Even though the final characters displayed on the console
+    #   look largely the same as what was displayed in earlier Ruby IRB versions,
+    #   this behavior completely changes the characters sequences sent to the
+    #   console and gathered by expect.
 
-    PTY.spawn(GITLAB_CONSOLE_COMMAND) do |console_read,console_write,pid|
+    debug("Loading gitlab-rails console and executing change (this can take some time)...\n")
 
-      # wait for the initial irb prompt and then get the user object
-      console_read.expect(/> /m, @options.load_timeout) { |msg|
-        raise("Unable to load console in #{@options.load_timeout} seconds") if msg.nil?
+    # Password will be wrapped in double quotes within a single-quoted bash string.
+    safe_password = @options.password.gsub(/"/,'\\"')
+    gitlab_ruby_commands = [
+      'user = User.where(username: "root")[0]',
+      "user.password = \"#{safe_password}\"",
+      "user.password_confirmation = \"#{safe_password}\"",
+      'user.save!'
+    ].join('; ')
 
-        debug(msg)
-        console_write.puts("user = User.where(username: 'root')[0]")
-      }
+    command = "echo '#{gitlab_ruby_commands}' | #{GITLAB_CONSOLE_COMMAND}"
+    debug("Executing: #{command}\n")
 
-      wait_for_irb_result(console_read)
+    begin
+      Timeout::timeout(@options.load_timeout) do
+        console_out = `#{command} 2>&1`
+        debug(console_out)
 
-      # wait for irb prompt and then set the password
-      console_read.expect(/> /, @options.cmd_timeout) { |msg|
-        raise("Command prompt not found in #{@options.cmd_timeout} seconds") if msg.nil?
+        # The last Ruby command executed in the Rails console (`user.save!`)
+        # returns true when the valid User record has been saved.  This is true
+        # even if you are overwriting the User record with the same information.
+        # Any failures in that command or a prior command in the semi-colon
+        # separated command list will spew out error messages instead.
 
-        debug(msg)
-        console_write.puts("user.password = '#{@options.password}'")
-      }
+        lines = console_out.split("\n").delete_if { |line| line.empty? }
 
-      wait_for_irb_result(console_read)
-
-      # wait for the irb prompt and then set the password confirmation
-      console_read.expect(/> /, @options.cmd_timeout) { |msg|
-        raise("Command prompt not found in #{@options.cmd_timeout} seconds") if msg.nil?
-
-        debug(msg)
-        console_write.puts("user.password_confirmation = '#{@options.password}'")
-      }
-
-      wait_for_irb_result(console_read)
-
-      # wait for the irb prompt and then save the password settings
-      console_read.expect(/> /, @options.cmd_timeout) { |msg|
-        raise("Command prompt not found in #{@options.cmd_timeout} seconds") if msg.nil?
-
-        debug(msg)
-        console_write.puts('user.save!')
-     }
-
-      wait_for_irb_result(console_read)
-
-      # wait for the irb prompt and then exit the gitlab-rails console
-      console_read.expect(/> /, @options.cmd_timeout) { |msg|
-        raise("Command prompt not found in #{@options.cmd_timeout} seconds") if msg.nil?
-
-        debug(msg)
-        debug("exit\n")
-        console_write.puts('exit')
-      }
+        if lines.last !~ /^true$/
+          raise('Password set operation failed.')
+        end
+      end
+    rescue Timeout::Error
+      err_msg = "Password set operation timed out after #{@options.load_timeout} seconds."
+      raise(err_msg)
     end
 
     puts 'GitLab root password set'
@@ -165,7 +174,16 @@ class GitlabRootPasswordChanger
 
   rescue Exception => e
     err_msg = "\nFAILED to set GitLab root password"
-    err_msg += ":\n#{e.message}" unless e.message.strip.empty?
+    err_msg += ":\n  #{e.message}" unless e.message.strip.empty?
+    err_msg += "\n"
+
+    unless @options.debug
+      # don't print out the actual password in this message so it
+      # doesn't end up in a Puppet log
+      debug_cmd = "#{PROGRAM_NAME} -v -t #{@options.load_timeout} <password>"
+      err_msg += "\nRun '#{debug_cmd}' manually to debug"
+    end
+
     warn(err_msg)
     return 1
   end
@@ -195,36 +213,11 @@ class GitlabRootPasswordChanger
     # Just in case the GitLab internals change and some other process is essential
     # for the gitlab-rails console, warn if any other GitLab process is not up.
     bad_status = status.select { |entry| entry.start_with?('down') }
-    warn("WARNING: GitLab is not completely running:\n#{bad_status.join("\n")}")
-  end
-
-  # Wait up to @options.cmd_timeout seconds for the string that indicates
-  # the result of the previous IRB command.
-  #
-  # @param read_io IO stream from which to read the results of the previous
-  #   IRB command
-  #
-  # @raise RuntimeError if the command fails
-  def wait_for_irb_result(read_io)
-    result = read_io.expect(/\n=>.*\n/m, @options.cmd_timeout)
-
-    if result.nil?
-      err_msg = "Valid command response not found in #{@options.cmd_timeout} seconds"
-
-      # Something went wrong. Try to grab the command executed and the
-      # exception message.
-      bad_result = read_io.expect(/(.*?)\n(.*)\nirb(.*)> /m, @options.cmd_timeout)
-
-      if bad_result
-        debug(bad_result[1].strip + "\n") # [1] command that failed
-        err_msg += ":\n#{bad_result[2]}"  # [2] error message
-      end
-
-      raise(err_msg)
-    else
-      debug(result)
+    unless bad_status.empty?
+      warn("WARNING: GitLab is not completely running:\n#{bad_status.join("\n")}")
     end
   end
+
 end
 
 ################################################################################


### PR DESCRIPTION
- Fixed a bug in which the change_gitlab_root_password script did
  not work for GitLab versions that included Ruby 2.7.x (GitLab 13.6.0
  and later).
- Fixed a bug in which the change_gitlab_root_password script emitted
  a 'WARNING: GitLab is not completely running' error message when
  GitLab was fully running.

SIMP-8980 #close