### PR TITLE
(SIMP-8958) Standardize assets in pupmod-simp-simp_gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,11 +45,13 @@ variables:
   BUNDLE_NO_PRUNE:   'true'
 
 
-# bundler dependencies + caching, optional RVM setup, with diagnostic output
-# --------------------------------------------------------------------------
+# bundler dependencies and caching
+#
+# - Cache bundler gems between pipelines foreach Ruby version
+# - Try to use cached and local resources before downloading dependencies
+# --------------------------------------
 .setup_bundler_env: &setup_bundler_env
   cache:
-    # Cache bundler gems between pipelines for each Ruby version
     key: "${CI_PROJECT_NAMESPACE}_ruby-${MATRIX_RUBY_VERSION}_bundler"
     paths:
       - '.vendor'
@@ -91,20 +93,16 @@ variables:
 
 # Assign a matrix level when your test will run.  Heavier jobs get higher numbers
 # NOTE: To skip all jobs with a SIMP_MATRIX_LEVEL, set SIMP_MATRIX_LEVEL=0
-# ------------------------------------------------------------------------------
 
 .relevant_file_conditions_trigger_spec_tests: &relevant_file_conditions_trigger_spec_tests
   changes:
     - .gitlab-ci.yml
     - .fixtures.yml
     - "spec/spec_helper.rb"
-    - "spec/{classes,unit,defines,type_aliases,types,hosts}/**/*.rb"
-    - "{manifests,files,types}/**/*"
-    - "templates/*.{erb,epp}"
-    - "lib/**/*"
+    - "spec/{classes,unit,defines,type_aliases,types,hosts,lib}/**/*.rb"
+    - "{SIMP,data,manifests,files,types,lib,functions}/**/*"
+    - "templates/**/*.{erb,epp}"
     - "Gemfile"
-    - "SIMP/**/*"
-    - "data/**/*"
   exists:
     - "spec/{classes,unit,defines,type_aliases,types,hosts}/**/*_spec.rb"
 
@@ -112,13 +110,11 @@ variables:
   changes:
     - .gitlab-ci.yml
     - "spec/spec_helper_acceptance.rb"
-    - "spec/acceptance/**/*"
-    - "{manifests,files,types}/**/*"
-    - "templates/*.{erb,epp}"
-    - "lib/**/*"
+    - "spec/{helpers,acceptance}/**/*"
+    - "spec/inspec_*/**/*"
+    - "{SIMP,data,manifests,files,types,lib,functions}/**/*"
+    - "templates/**/*.{erb,epp}"
     - "Gemfile"
-    - "SIMP/**/*"
-    - "data/**/*"
   exists:
     - "spec/acceptance/**/*_spec.rb"
 
@@ -219,33 +215,40 @@ variables:
 # Puppet Versions
 #-----------------------------------------------------------------------
 
-.pup_5: &pup_5
+.pup_5_x: &pup_5_x
   image: 'ruby:2.4'
   variables:
     PUPPET_VERSION: '~> 5.0'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
-.pup_6: &pup_6
+.pup_5_pe: &pup_5_pe
+  image: 'ruby:2.4'
+  variables:
+    PUPPET_VERSION: '5.5.22'
+    BEAKER_PUPPET_COLLECTION: 'puppet5'
+    MATRIX_RUBY_VERSION: '2.4'
+
+.pup_6_x: &pup_6_x
   image: 'ruby:2.5'
   variables:
     PUPPET_VERSION: '~> 6.0'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
-.pup_6_18_0: &pup_6_18_0
+.pup_6_pe: &pup_6_pe
   image: 'ruby:2.5'
   variables:
     PUPPET_VERSION: '6.18.0'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
-.pup_7: &pup_7
-  image: 'ruby:2.5'
+.pup_7_x: &pup_7_x
+  image: 'ruby:2.7'
   variables:
     PUPPET_VERSION: '~> 7.0'
     BEAKER_PUPPET_COLLECTION: 'puppet7'
-    MATRIX_RUBY_VERSION: '2.5'
+    MATRIX_RUBY_VERSION: '2.7'
 
 # Testing Environments
 #-----------------------------------------------------------------------
@@ -284,7 +287,7 @@ variables:
 #=======================================================================
 
 releng_checks:
-  <<: *pup_5
+  <<: *pup_5_x
   <<: *setup_bundler_env
   stage: 'validation'
   tags: ['docker']
@@ -300,31 +303,39 @@ releng_checks:
 # Linting
 #-----------------------------------------------------------------------
 
+# NOTE: Don't add more lint checks here.
+#       puppet-lint is a validator, not a parser; it includes its own lexer and
+#       doesn't use the Puppet gem at all.  Running multiple lint tests against
+#       different Puppet versions won't accomplish anything.
+
 pup-lint:
-  <<: *pup_6
+  <<: *pup_6_x
   <<: *lint_tests
 
 # Unit Tests
 #-----------------------------------------------------------------------
 
-pup5-unit:
-  <<: *pup_5
+pup5.x-unit:
+  <<: *pup_5_x
   <<: *unit_tests
   <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
-pup6-unit:
-  <<: *pup_6
+pup5.pe-unit:
+  <<: *pup_5_pe
+  <<: *unit_tests
+
+pup6.x-unit:
+  <<: *pup_6_x
   <<: *unit_tests
   <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
-pup6.18.0-unit:
-  <<: *pup_6_18_0
+pup6.pe-unit:
+  <<: *pup_6_pe
   <<: *unit_tests
 
-pup7-unit:
-  <<: *pup_7
+pup7.x-unit:
+  <<: *pup_7_x
   <<: *unit_tests
-  <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
 # ------------------------------------------------------------------------------
 #             NOTICE: **This file is maintained with puppetsync**
@@ -336,91 +347,91 @@ pup7-unit:
 # Repo-specific content
 # ==============================================================================
 
-pup5-el7:
-  <<: *pup_5
+pup5.x-el7:
+  <<: *pup_5_x
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,centos-7-x86_64]'
 
 # # FIPS is not supported by gitlab yet
-#pup5-el7-fips:
-#  <<: *pup_5
+#pup5.x-el7-fips:
+#  <<: *pup_5_x
 #  <<: *acceptance_base
 #  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
 #  script:
 #    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,centos-7-x86_64]'
 
-pup5-oel:
-  <<: *pup_5
+pup5.x-oel:
+  <<: *pup_5_x
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'bundle exec rake beaker:suites[default,oel-7-x86_64]'
 
 # # FIPS is not supported by gitlab yet
-#pup5-oel7-fips:
-#  <<: *pup_5
+#pup5.x-oel7-fips:
+#  <<: *pup_5_x
 #  <<: *acceptance_base
 #  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
 #  script:
 #    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel-7-x86_64]'
 
-pup6-el7:
-  <<: *pup_6
+pup6.x-el7:
+  <<: *pup_6_x
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
     - 'bundle exec rake beaker:suites[default,centos-7-x86_64]'
 
 # # FIPS is not supported by gitlab yet
-#pup6-el7-fips:
-#  <<: *pup_6
+#pup6.x-el7-fips:
+#  <<: *pup_6_x
 #  <<: *acceptance_base
 #  script:
 #    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,centos-7-x86_64]'
 
 # Test with the oldest version of GitLab we support
-pup6-el7-gitlab12_min:
-  <<: *pup_6
+pup6.x-el7-gitlab12_min:
+  <<: *pup_6_x
   <<: *acceptance_base
   script:
     - 'TEST_GITLAB_CE_VERSION=12.3.0 bundle exec rake beaker:suites[default,centos-7-x86_64]'
 
-pup6-el8:
-  <<: *pup_6
+pup6.x-el8:
+  <<: *pup_6_x
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
     - 'bundle exec rake beaker:suites[default,centos-8-x86_64]'
 
 # # FIPS is not supported by gitlab yet
-#pup6-el8-fips:
-#  <<: *pup_6
+#pup6.x-el8-fips:
+#  <<: *pup_6_x
 #  <<: *acceptance_base
 #  script:
 #    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,centos-8-x86_64]'
 
-pup6.18.0-el7:
-  <<: *pup_6_18_0
+pup6.pe-el7:
+  <<: *pup_6_pe
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,centos-7-x86_64]'
 
-pup6.18.0-el8:
-  <<: *pup_6_18_0
+pup6.pe-el8:
+  <<: *pup_6_pe
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,centos-8-x86_64]'
 
-pup6.18.0-oel7:
-  <<: *pup_6_18_0
+pup6.pe-oel7:
+  <<: *pup_6_pe
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
     - 'bundle exec rake beaker:suites[default,oel-7-x86_64]'
 
-pup6.18.0-oel8:
-  <<: *pup_6_18_0
+pup6.pe-oel8:
+  <<: *pup_6_pe
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  puppet_version = ENV['PUPPET_VERSION'] || '~> 5.5'
+  puppet_version = ENV['PUPPET_VERSION'] || '~> 6.18'
   major_puppet_version = puppet_version.scan(/(\d+)(?:\.|\Z)/).flatten.first.to_i
   gem 'rake'
   gem 'puppet', puppet_version


### PR DESCRIPTION
This patch baselines the latest standardized assets for Puppet modules.

SIMP-9083 #close
[SIMP-8958] #comment Standardized assets in pupmod-simp-simp_gitlab
[SIMP-8489] #comment Updated pupmod-simp-simp_gitlab GLCI pipeline to Puppet 6.18
[SIMP-8923] #comment Renamed 'sanity' to 'releng' in pupmod-simp-simp_gitlab
[SIMP-8984] #comment Updated pupmod-simp-simp_gitlab to new GLCI conventions

[SIMP-8958]: https://simp-project.atlassian.net/browse/SIMP-8958
[SIMP-8489]: https://simp-project.atlassian.net/browse/SIMP-8489
[SIMP-8923]: https://simp-project.atlassian.net/browse/SIMP-8923
[SIMP-8984]: https://simp-project.atlassian.net/browse/SIMP-8984