### PR TITLE
(SIMP-9427) simp_gitlab ldap test fails GitLab 13.9.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Apr 21 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.6.2
+- Update GitLab ticket URLs in README
+
 * Thu Jan 07 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.6.1
 - Fixed a bug in which the change_gitlab_root_password script did
   not work for GitLab versions that included Ruby 2.7.x (GitLab 13.6.0

--- a/README.md
+++ b/README.md
@@ -267,9 +267,9 @@ TLS settings as GitLab's web server―which is something that [we try to keep
 distinct][distinct_tls], as there could be situations in which their
 configurations legitimately vary.
 
-[ldap_ca_file_problems]: https://gitlab.com/gitlab-org/gitlab-ce/issues/40003
-[ce37254_workarounds]: https://gitlab.com/gitlab-org/gitlab-ce/issues/37254#note_45543716
-[ce37254_trusted_wo_ca_file]: https://gitlab.com/gitlab-org/gitlab-ce/issues/37254#note_3894021
+[ldap_ca_file_problems]: https://gitlab.com/gitlab-org/gitlab-foss/issues/40003
+[ce37254_workarounds]: https://gitlab.com/gitlab-org/gitlab-foss/issues/37254#note_45543716
+[ce37254_trusted_wo_ca_file]: https://gitlab.com/gitlab-org/gitlab-foss/issues/37254#note_3894021
 [distinct_tls]: https://github.com/simp/pupmod-simp-simp_openldap/blob/master/manifests/client.pp#L15-L18
 
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_gitlab",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": "SIMP Team",
   "summary": "SIMP profiles for GitLab",
   "license": "Apache-2.0",


### PR DESCRIPTION
* Test update:
  * Updated the LDAP web-page-scrapping logic to work with
    both GitLab 12.3.0 and the latest GitLab (13.10.3).
* Docs update:
  * Fixed a few GitLab ticket URLs in the README.

SIMP-9427 #close