### PR TITLE
(SIMP-9712) simp_gitlab tests fail OEL7

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,9 @@
 ---
 fixtures:
   repositories:
+    augeas_core:
+      repo: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
+      puppet_version: ">= 6.0.0"
     augeasproviders_core: https://github.com/simp/augeasproviders_core
     augeasproviders_ssh: https://github.com/simp/augeasproviders_ssh
     chrony: https://github.com/simp/pupmod-aboe76-chrony

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -357,92 +357,71 @@ pup7.x-unit:
 # Repo-specific content
 # ==============================================================================
 
-pup5.x-el7:
-  <<: *pup_5_x
-  <<: *acceptance_base
-  script:
-    - 'bundle exec rake beaker:suites[default,centos-7-x86_64]'
-
-# # FIPS is not supported by gitlab yet
-#pup5.x-el7-fips:
-#  <<: *pup_5_x
-#  <<: *acceptance_base
-#  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
-#  script:
-#    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,centos-7-x86_64]'
-
-pup5.x-oel:
-  <<: *pup_5_x
-  <<: *acceptance_base
-  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
-  script:
-    - 'bundle exec rake beaker:suites[default,oel-7-x86_64]'
-
-# # FIPS is not supported by gitlab yet
-#pup5.x-oel7-fips:
-#  <<: *pup_5_x
-#  <<: *acceptance_base
-#  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
-#  script:
-#    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel-7-x86_64]'
-
-pup6.x-el7:
+# Test with the GitLab latest version with the latest OS.  It may fail (i.e., we
+# have seen breaking changes on minor GitLab releases), but we want to try it
+# every time to have an early-warning of problems.
+pup6.x-el8-latest:
   <<: *pup_6_x
   <<: *acceptance_base
-  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
-  script:
-    - 'bundle exec rake beaker:suites[default,centos-7-x86_64]'
-
-# # FIPS is not supported by gitlab yet
-#pup6.x-el7-fips:
-#  <<: *pup_6_x
-#  <<: *acceptance_base
-#  script:
-#    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,centos-7-x86_64]'
-
-# Test with the oldest version of GitLab we support
-pup6.x-el7-gitlab12_min:
-  <<: *pup_6_x
-  <<: *acceptance_base
-  script:
-    - 'TEST_GITLAB_CE_VERSION=12.3.0 bundle exec rake beaker:suites[default,centos-7-x86_64]'
-
-pup6.x-el8:
-  <<: *pup_6_x
-  <<: *acceptance_base
-  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
+  allow_failure: true
   script:
     - 'bundle exec rake beaker:suites[default,centos-8-x86_64]'
 
+
+# Test with the last GitLab version that we know works (aka stable).
+# - Can't use a variable for the version and retain compatibility with puppetsync.
+# - Last stable GitLab version = 13.11.5
+# - **If you change this, also change the version in the README.md**.
+#
+pup6.x-el7-stable:
+  <<: *pup_6_x
+  <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
+  script:
+    - 'TEST_GITLAB_CE_VERSION=13.11.5 bundle exec rake beaker:suites[default,centos-7-x86_64]'
+
+pup6.x-el8-stable:
+  <<: *pup_6_x
+  <<: *acceptance_base
+  script:
+    - 'TEST_GITLAB_CE_VERSION=13.11.5 bundle exec rake beaker:suites[default,centos-8-x86_64]'
+
 # # FIPS is not supported by gitlab yet
-#pup6.x-el8-fips:
+#pup6.x-el8-fips-stable:
 #  <<: *pup_6_x
 #  <<: *acceptance_base
+#  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
 #  script:
-#    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,centos-8-x86_64]'
+#    - 'BEAKER_fips=yes TEST_GITLAB_CE_VERSION=13.11.5 bundle exec rake beaker:suites[default,centos-8-x86_64]'
 
-pup6.pe-el7:
+pup6.pe-el7-stable:
   <<: *pup_6_pe
   <<: *acceptance_base
   script:
-    - 'bundle exec rake beaker:suites[default,centos-7-x86_64]'
+    - 'TEST_GITLAB_CE_VERSION=13.11.5 bundle exec rake beaker:suites[default,centos-7-x86_64]'
 
-pup6.pe-el8:
+pup6.pe-el8-stable:
   <<: *pup_6_pe
   <<: *acceptance_base
   script:
-    - 'bundle exec rake beaker:suites[default,centos-8-x86_64]'
+    - 'TEST_GITLAB_CE_VERSION=13.11.5 bundle exec rake beaker:suites[default,centos-8-x86_64]'
 
-pup6.pe-oel7:
+# # FIPS is not supported by gitlab yet
+#pup6.pe-el8-fips-stable:
+#  <<: *pup_6_pe
+#  <<: *acceptance_base
+#  script:
+#    - 'BEAKER_fips=yes TEST_GITLAB_CE_VERSION=13.11.5 bundle exec rake beaker:suites[default,centos-8-x86_64]'
+
+pup6.pe-oel7-stable:
   <<: *pup_6_pe
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
-    - 'bundle exec rake beaker:suites[default,oel-7-x86_64]'
+    - 'TEST_GITLAB_CE_VERSION=13.11.5 bundle exec rake beaker:suites[default,oel-7-x86_64]'
 
-pup6.pe-oel8:
+pup6.pe-oel8-stable:
   <<: *pup_6_pe
   <<: *acceptance_base
-  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
-    - 'bundle exec rake beaker:suites[default,oel-8-x86_64]'
+    - 'TEST_GITLAB_CE_VERSION=13.11.5 bundle exec rake beaker:suites[default,oel-8-x86_64]'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
-* Wed Apr 21 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.6.2
-- Update GitLab ticket URLs in README
+* Thu Jun 03 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.6.2
+- Minor README updates
+  - Clarify versions of GitLab this modules is known to work with and
+    the steps a user can do to verify it works with a different version.
+  - Update GitLab ticket URLs.
 
 * Thu Jan 07 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.6.1
 - Fixed a bug in which the change_gitlab_root_password script did

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.21.4', '< 2']
+  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.23.2', '< 2']
 end
 
 # Evaluate extra gemfiles if they exist

--- a/README.md
+++ b/README.md
@@ -120,14 +120,22 @@ As a profile module, `simp_gitlab` has a few functions:
 
 ### Setup Requirements
 
-This module supports GitLab 12.3.0 or later.
+#### Supported GitLab versions
+
+This module was last tested with GitLab Community Edition 13.11.5.
+It may work for other GitLab versions. You can verify it works for a specific
+version by [executing the acceptance tests with that version](#acceptance-tests).
+
+#### Isolated network requirements
 
 If using this module from an isolated network, ensure that package and repo
 management are disabled from the module, and that the `gitlab-ce` or
 `gitlab-ee` package is installed.  Be sure that the `$simp_gitlab::edition`
 parameter is set to the correct edition.
 
-### Upgrade to 0.6.0
+#### Upgrade caveats
+
+##### Upgrade to 0.6.0
 
 simp_gitlab version 0.6.0 introduced a new mechanism for setting the GitLab
 root user password upon initial installation of GitLab. As a side effect,
@@ -140,7 +148,7 @@ to reset the GitLab root password, simply run
  `/usr/local/sbin/change_gitlab_root_password <new_password>` manually.
 You do not need to know the previous password to set the new password.
 
-### Upgrade to 0.3.0
+##### Upgrade to 0.3.0
 
 Upgrading from simp_gitlab 0.2.0 to 0.3.0 requires you to copy the authorized key file
 from `/etc/ssh/local_keys/git` to `/var/opt/gitlab/.ssh/authorized_keys`. Alternately
@@ -352,9 +360,10 @@ for more information.
 to specify the version of gitlab-ce to use in the acceptance tests.
 When set, it must either a version string for a specific gitlab-ce
 package version or 'latest' to indicate the latest available version.
+When unset, the latest version is tested.
 
 ```shell
-TEST_GITLAB_CE_VERSION=latest bundle exec rake beaker:suites
+TEST_GITLAB_CE_VERSION=13.11.5 bundle exec rake beaker:suites
 ```
 
 #### Environment variable `TRUSTED_NETS`

--- a/spec/acceptance/suites/default/10_ldaps_spec.rb
+++ b/spec/acceptance/suites/default/10_ldaps_spec.rb
@@ -58,6 +58,18 @@ describe 'simp_gitlab using ldap' do
     EOS
   end
 
+  hosts_with_role(hosts, 'ldapserver').each do |ldapserver|
+    context "on LDAP server #{ldapserver}" do
+      it 'should enable additional OS repos as needed' do
+        result = on(ldapserver, 'cat /etc/oracle-release', :accept_all_exit_codes => true)
+        if (result.exit_code == 0) && ldapserver[:platform].match(/el-7/)
+          # OEL 7 needs another repo enabled for the openssh-ldap package
+          ldapserver.install_package('yum-utils')
+          on(ldapserver, 'yum-config-manager --enable ol7_optional_latest')
+        end
+      end
+    end
+  end
 
   context 'with TLS & PKI enabled' do
     shared_examples_for 'a web login for LDAP users' do |ldap_proto|

--- a/spec/acceptance/suites/default/support/manifests/remove_gitlab.pp
+++ b/spec/acceptance/suites/default/support/manifests/remove_gitlab.pp
@@ -1,9 +1,4 @@
-$test_binary = $facts['os']['release']['major'] ? {
-  '6' => '/usr/bin/test',
-  '7' => '/bin/test',
-  '8' => '/bin/test',
-}
-
+$test_binary = '/bin/test'
 
 # NOTE: for the purposes of resetting GitLab, it _should_ be enough to
 # run `gitlab-ctl cleanse`.  However, that hasn't always been enough
@@ -25,12 +20,17 @@ exec{['/opt/gitlab/bin/gitlab-ctl cleanse',
 
 exec{'/bin/rm -rf /run/gitlab*':
   tag => 'after_uninstall',
-  onlyif => "${test_binary} -f /run/gitlab*",
+  onlyif => "${test_binary} -d /run/gitlab*",
 }
 
 exec{'/bin/rm -rf /opt/gitlab*':
   tag => 'after_uninstall',
-  onlyif => "${test_binary} -f /opt/gitlab*",
+  onlyif => "${test_binary} -d /opt/gitlab*",
+}
+
+exec{'/bin/rm -rf /var/log/gitlab*':
+  tag => 'after_uninstall',
+  onlyif => "${test_binary} -d /var/log/gitlab*",
 }
 
 file{ '/usr/lib/systemd/system/gitlab-runsvdir.service':

--- a/spec/acceptance/support/shared_examples/gitlab_web_service.rb
+++ b/spec/acceptance/support/shared_examples/gitlab_web_service.rb
@@ -31,7 +31,18 @@ shared_examples_for 'a GitLab web service' do |gitlab_signin_url, options|
       permitted_client,
       "#{curl_ssl_cmd(permitted_client)} -L #{gitlab_signin_url}"
     )
-    expect(result.stdout).to match(/GitLab|password/)
+
+    # These web-page-scraping checks are inherently fragile, but the best we
+    # can do...
+    root_pw_change_page =
+      !result.stdout.match(/reset_password_token/).nil? ||
+      (
+        !result.stdout.match(/New password/).nil? &&
+        !result.stdout.match(/Confirm new password/).nil?
+      )
+    expect(root_pw_change_page).to be(false), 'Root password not set:  root password change page detected'
+    expect(result.stdout).to match(/GitLab/)
+    expect(result.stdout).to match(/Forgot your password/), 'Login page not detected'
   end
 
   it 'denies web access from unknown clients' do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -29,6 +29,10 @@ RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   fix_errata_on hosts
 
+  # Detect cases in which no examples are executed (e.g., nodeset does not
+  # have hosts with required roles)
+  c.fail_if_no_examples = true
+
   # Readable test descriptions
   c.formatter = :documentation
 


### PR DESCRIPTION
Fixed OEL7 acceptance test when run with gitlab < 13.12.
LDAP test failures with gitlab > 13.11 will be addressed in
a separate ticket.

Other changes:

- Updated README.md (minor). The most notable change is the addition of a
  section called "Supported GitLab versions". This section lists the last
  version of GitLab this module was known to work with and how to
  test with other versions. Although this may be a pain to keep updated,
  we need to keep track of this information because GitLab has broken
  functionality with minor GitLab release (e.g., GitLab bug we detected when
  testing with 13.12.1) and, at this time, we don't have resources to
  verify interoperability with every GitLab release.

- Test changes
  - Improved detection of root login page during acceptance tests.
  - Dropped acceptance testing with minimum GitLab version.
    - Users can use an earlier version of this module if they need
      interoperability with old GitLab versions.
  - Reworked .gitlab-ci.yml to test with last version of GitLab known to
    work with this module.
    - Still test with the latest GitLab to have early warning of issues,
      but allow that test to fail.
  - Fail acceptance tests if no examples are executed.

SIMP-9712 #close
SIMP-9666 #comment pupmod-simp-simp_gitlab acceptance tests configured