### PR TITLE
(SIMP-9281) simp_gitlab: update 2 module dependencies

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,27 +4,27 @@ fixtures:
     augeas_core:
       repo: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
       puppet_version: ">= 6.0.0"
-    augeasproviders_core: https://github.com/simp/augeasproviders_core
-    augeasproviders_ssh: https://github.com/simp/augeasproviders_ssh
-    chrony: https://github.com/simp/pupmod-aboe76-chrony
-    concat: https://github.com/simp/puppetlabs-concat
-    firewalld: https://github.com/simp/pupmod-voxpupuli-firewalld
+    augeasproviders_core: https://github.com/simp/augeasproviders_core.git
+    augeasproviders_ssh: https://github.com/simp/augeasproviders_ssh.git
+    chrony: https://github.com/simp/pupmod-voxpupuli-chrony.git
+    concat: https://github.com/simp/puppetlabs-concat.git
+    firewalld: https://github.com/simp/pupmod-voxpupuli-firewalld.git
     gitlab: https://github.com/simp/puppet-gitlab.git
-    iptables: https://github.com/simp/pupmod-simp-iptables
-    pam: https://github.com/simp/pupmod-simp-pam
-    pki: https://github.com/simp/pupmod-simp-pki
-    postfix: https://github.com/simp/pupmod-simp-postfix
-    rsyslog: https://github.com/simp/pupmod-simp-rsyslog
-    ssh: https://github.com/simp/pupmod-simp-ssh
-    simplib: https://github.com/simp/pupmod-simp-simplib
-    simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld
-    stdlib: https://github.com/simp/puppetlabs-stdlib
-    svckill: https://github.com/simp/pupmod-simp-svckill
+    iptables: https://github.com/simp/pupmod-simp-iptables.git
+    pam: https://github.com/simp/pupmod-simp-pam.git
+    pki: https://github.com/simp/pupmod-simp-pki.git
+    postfix: https://github.com/simp/pupmod-simp-postfix.git
+    rsyslog: https://github.com/simp/pupmod-simp-rsyslog.git
+    ssh: https://github.com/simp/pupmod-simp-ssh.git
+    simplib: https://github.com/simp/pupmod-simp-simplib.git
+    simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld.git
+    stdlib: https://github.com/simp/puppetlabs-stdlib.git
+    svckill: https://github.com/simp/pupmod-simp-svckill.git
     yumrepo_core:
       repo: https://github.com/simp/pupmod-puppetlabs-yumrepo_core.git
       puppet_version: ">= 6.0.0"
 
     # Fixtures required for the acceptance tests
-    simp_openldap: https://github.com/simp/pupmod-simp-simp_openldap
+    simp_openldap: https://github.com/simp/pupmod-simp-simp_openldap.git
   symlinks:
     simp_gitlab: "#{source_dir}"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,11 @@
-* Thu Jun 03 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.6.2
+* Fri Jun 04 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.6.2
 - Minor README updates
   - Clarify versions of GitLab this modules is known to work with and
     the steps a user can do to verify it works with a different version.
   - Update GitLab ticket URLs.
+- Allow herculesteam/augeasproviders_ssh < 5.0.0
+- Use puppet/chrony in lieu of aboe/chrony, as VoxPupuli has now assumed
+  ownership of this module.
 
 * Thu Jan 07 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.6.1
 - Fixed a bug in which the change_gitlab_root_password script did

--- a/metadata.json
+++ b/metadata.json
@@ -16,12 +16,12 @@
   ],
   "dependencies": [
     {
-      "name": "aboe/chrony",
-      "version_requirement": ">= 0.3.1 < 1.0.0"
+      "name": "puppet/chrony",
+      "version_requirement": ">= 1.0.0 < 2.0.0"
     },
     {
       "name": "herculesteam/augeasproviders_ssh",
-      "version_requirement": ">= 2.5.0 < 4.0.0"
+      "version_requirement": ">= 2.5.0 < 5.0.0"
     },
     {
       "name": "puppet/gitlab",

--- a/spec/acceptance/suites/default/10_ldaps_spec.rb
+++ b/spec/acceptance/suites/default/10_ldaps_spec.rb
@@ -58,14 +58,14 @@ describe 'simp_gitlab using ldap' do
     EOS
   end
 
-  hosts_with_role(hosts, 'ldapserver').each do |ldapserver|
-    context "on LDAP server #{ldapserver}" do
+  hosts.each do |host|
+    context "on host #{host}" do
       it 'should enable additional OS repos as needed' do
-        result = on(ldapserver, 'cat /etc/oracle-release', :accept_all_exit_codes => true)
-        if (result.exit_code == 0) && ldapserver[:platform].match(/el-7/)
+        result = on(host, 'cat /etc/oracle-release', :accept_all_exit_codes => true)
+        if (result.exit_code == 0) && host[:platform].match(/el-7/)
           # OEL 7 needs another repo enabled for the openssh-ldap package
-          ldapserver.install_package('yum-utils')
-          on(ldapserver, 'yum-config-manager --enable ol7_optional_latest')
+          host.install_package('yum-utils')
+          on(host, 'yum-config-manager --enable ol7_optional_latest')
         end
       end
     end


### PR DESCRIPTION
- Fix OEL7 test, take 2
- Update to augeasproviders_ssh < 5.0.0. Version was bumped to 4.0.0 because
  the module dropped support for Augeas < 1.0.0.
- Use puppet/chrony in lieu of aboe/chrony, as VoxPupuli has now assumed
  ownership of this module.
- Make sure all fixture URLs end in '.git', as not all private
  GitHub mirrors allow shortened URL

SIMP-9281 #comment simp_gitlab
SIMP-9761 #comment simp_gitlab