### PR TITLE
(SIMP-9281) simp/simp_gitlab Additional dependency updates

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -11,8 +11,6 @@
 # The testing matrix considers ruby/puppet versions supported by SIMP and PE:
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby    EOL
-# SIMP 6.4      5.5      2.40    TBD
-# PE 2018.1     5.5      2.40    2021-01 (LTS overlap)
 # PE 2019.8     6.18     2.5     2022-12 (LTS)
 #
 # https://puppet.com/docs/pe/2018.1/component_versions_in_recent_pe_releases.html
@@ -114,9 +112,6 @@ jobs:
           - label: 'Puppet 6.18 [SIMP 6.5/PE 2019.8]'
             puppet_version: '~> 6.18.0'
             ruby_version: '2.5'
-          - label: 'Puppet 5.5 [SIMP 6.4/PE 2018.1]'
-            puppet_version: '~> 5.5.22'
-            ruby_version: '2.4'
           - label: 'Puppet 7.x'
             puppet_version: '~> 7.0'
             ruby_version: '2.7'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,8 +13,6 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby    EOL
-# SIMP 6.4      5.5      2.4.10  TBD
-# PE 2018.1     5.5      2.4.10  2021-01 (LTS overlap)
 # PE 2019.8     6.18     2.5.7   2022-12 (LTS)
 ---
 
@@ -224,20 +222,6 @@ variables:
 # Puppet Versions
 #-----------------------------------------------------------------------
 
-.pup_5_x: &pup_5_x
-  image: 'ruby:2.4'
-  variables:
-    PUPPET_VERSION: '~> 5.0'
-    BEAKER_PUPPET_COLLECTION: 'puppet5'
-    MATRIX_RUBY_VERSION: '2.4'
-
-.pup_5_pe: &pup_5_pe
-  image: 'ruby:2.4'
-  variables:
-    PUPPET_VERSION: '5.5.22'
-    BEAKER_PUPPET_COLLECTION: 'puppet5'
-    MATRIX_RUBY_VERSION: '2.4'
-
 .pup_6_x: &pup_6_x
   image: 'ruby:2.5'
   variables:
@@ -324,15 +308,6 @@ pup-lint:
 
 # Unit Tests
 #-----------------------------------------------------------------------
-
-pup5.x-unit:
-  <<: *pup_5_x
-  <<: *unit_tests
-  <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
-
-pup5.pe-unit:
-  <<: *pup_5_pe
-  <<: *unit_tests
 
 pup6.x-unit:
   <<: *pup_6_x

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,16 @@
-* Fri Jun 04 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.6.2
-- Minor README updates
-  - Clarify versions of GitLab this modules is known to work with and
-    the steps a user can do to verify it works with a different version.
-  - Update GitLab ticket URLs.
-- Allow herculesteam/augeasproviders_ssh < 5.0.0
-- Use puppet/chrony in lieu of aboe/chrony, as VoxPupuli has now assumed
-  ownership of this module.
+* Fri Jun 04 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.7.0
+- Removed
+  - Drop support for Puppet 5
+- Changed
+  - Minor README updates
+    - Clarify versions of GitLab this modules is known to work with and
+      the steps a user can do to verify it works with a different version.
+    - Update GitLab ticket URLs.
+  - Allow herculesteam/augeasproviders_ssh < 5.0.0
+  - Allow puppet/gitlab < 8.0.0
+  - Allow puppetlabs/stdlib < 8.0.0
+  - Use puppet/chrony in lieu of aboe/chrony, as VoxPupuli has now assumed
+    ownership of this module.
 
 * Thu Jan 07 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.6.1
 - Fixed a bug in which the change_gitlab_root_password script did

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_gitlab",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "author": "SIMP Team",
   "summary": "SIMP profiles for GitLab",
   "license": "Apache-2.0",
@@ -25,11 +25,11 @@
     },
     {
       "name": "puppet/gitlab",
-      "version_requirement": ">= 6.0.1 < 7.0.0"
+      "version_requirement": ">= 6.0.1 < 8.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 7.0.0"
+      "version_requirement": ">= 4.13.1 < 8.0.0"
     },
     {
       "name": "simp/iptables",
@@ -86,7 +86,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 7.0.0"
     }
   ]
 }


### PR DESCRIPTION
- Removed
  - Drop support for Puppet 5
- Changed
  - Allow puppet/gitlab < 8.0.0
  - Allow puppetlabs/stdlib < 8.0.0

SIMP-9281 #comment pupmod-simp-simp_gitlab updates