### PR TITLE
(SIMP-9747) simp_gitlab acceptance tests fail old GitLab version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -345,7 +345,7 @@ pup6.x-el8-latest:
 
 # Test with the last GitLab version that we know works (aka stable).
 # - Can't use a variable for the version and retain compatibility with puppetsync.
-# - Last stable GitLab version = 13.11.5
+# - Last stable GitLab version = 14.0.0
 # - **If you change this, also change the version in the README.md**.
 #
 pup6.x-el7-stable:
@@ -353,50 +353,54 @@ pup6.x-el7-stable:
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
-    - 'TEST_GITLAB_CE_VERSION=13.11.5 bundle exec rake beaker:suites[default,centos-7-x86_64]'
+    - 'TEST_GITLAB_CE_VERSION=14.0.0 bundle exec rake beaker:suites[default,centos-7-x86_64]'
 
 pup6.x-el8-stable:
   <<: *pup_6_x
   <<: *acceptance_base
   script:
-    - 'TEST_GITLAB_CE_VERSION=13.11.5 bundle exec rake beaker:suites[default,centos-8-x86_64]'
+    - 'TEST_GITLAB_CE_VERSION=14.0.0 bundle exec rake beaker:suites[default,centos-8-x86_64]'
 
-# # FIPS is not supported by gitlab yet
-#pup6.x-el8-fips-stable:
-#  <<: *pup_6_x
-#  <<: *acceptance_base
-#  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
-#  script:
-#    - 'BEAKER_fips=yes TEST_GITLAB_CE_VERSION=13.11.5 bundle exec rake beaker:suites[default,centos-8-x86_64]'
+pup6.x-el8-fips-stable:
+  <<: *pup_6_x
+  <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
+  script:
+    - 'BEAKER_fips=yes TEST_GITLAB_CE_VERSION=14.0.0 bundle exec rake beaker:suites[default,centos-8-x86_64]'
 
 pup6.pe-el7-stable:
   <<: *pup_6_pe
   <<: *acceptance_base
   script:
-    - 'TEST_GITLAB_CE_VERSION=13.11.5 bundle exec rake beaker:suites[default,centos-7-x86_64]'
+    - 'TEST_GITLAB_CE_VERSION=14.0.0 bundle exec rake beaker:suites[default,centos-7-x86_64]'
 
 pup6.pe-el8-stable:
   <<: *pup_6_pe
   <<: *acceptance_base
   script:
-    - 'TEST_GITLAB_CE_VERSION=13.11.5 bundle exec rake beaker:suites[default,centos-8-x86_64]'
+    - 'TEST_GITLAB_CE_VERSION=14.0.0 bundle exec rake beaker:suites[default,centos-8-x86_64]'
 
-# # FIPS is not supported by gitlab yet
-#pup6.pe-el8-fips-stable:
-#  <<: *pup_6_pe
-#  <<: *acceptance_base
-#  script:
-#    - 'BEAKER_fips=yes TEST_GITLAB_CE_VERSION=13.11.5 bundle exec rake beaker:suites[default,centos-8-x86_64]'
+pup6.pe-el8-fips-stable:
+  <<: *pup_6_pe
+  <<: *acceptance_base
+  script:
+    - 'BEAKER_fips=yes TEST_GITLAB_CE_VERSION=14.0.0 bundle exec rake beaker:suites[default,centos-8-x86_64]'
 
 pup6.pe-oel7-stable:
   <<: *pup_6_pe
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
-    - 'TEST_GITLAB_CE_VERSION=13.11.5 bundle exec rake beaker:suites[default,oel-7-x86_64]'
+    - 'TEST_GITLAB_CE_VERSION=14.0.0 bundle exec rake beaker:suites[default,oel-7-x86_64]'
 
 pup6.pe-oel8-stable:
   <<: *pup_6_pe
   <<: *acceptance_base
   script:
-    - 'TEST_GITLAB_CE_VERSION=13.11.5 bundle exec rake beaker:suites[default,oel-8-x86_64]'
+    - 'TEST_GITLAB_CE_VERSION=14.0.0 bundle exec rake beaker:suites[default,oel-8-x86_64]'
+
+pup7.x-el8-stable:
+  <<: *pup_7_x
+  <<: *acceptance_base
+  script:
+    - 'TEST_GITLAB_CE_VERSION=14.0.0 bundle exec rake beaker:suites[default,centos-8-x86_64]'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,19 +1,25 @@
-* Thu Jun 17 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.7.0
-- Ensured support for Puppet 7 in requirements and stdlib
-
-* Fri Jun 04 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.7.0
+* Tue Jun 22 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.7.0
 - Removed
-  - Drop support for Puppet 5
+  - Dropped support for Puppet 5
 - Changed
+  - `simp_gitlab::allow_fips` now defaults to true, as the last version of
+     GitLab this module was tested with, 14.0.0, supports FIPS mode.
+     - This will allow new GitLab installations on servers for which FIPS-mode
+       is enabled, but not affect existing GitLab servers configured by earlier
+       versions of this module.
   - Minor README updates
     - Clarify versions of GitLab this modules is known to work with and
       the steps a user can do to verify it works with a different version.
+    - Remove OBE FIPS-mode failure
     - Update GitLab ticket URLs.
   - Allow herculesteam/augeasproviders_ssh < 5.0.0
   - Allow puppet/gitlab < 8.0.0
   - Allow puppetlabs/stdlib < 8.0.0
   - Use puppet/chrony in lieu of aboe/chrony, as VoxPupuli has now assumed
     ownership of this module.
+
+* Thu Jun 17 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.7.0
+- Ensured support for Puppet 7 in requirements and stdlib
 
 * Thu Jan 07 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.6.1
 - Fixed a bug in which the change_gitlab_root_password script did

--- a/README.md
+++ b/README.md
@@ -93,8 +93,6 @@ As a profile module, `simp_gitlab` has a few functions:
     - `simp_options::tcpwrappers`: Nothing in Omnibus is linked to TCP Wrapper
     - `simp_options::auditing`: Nothing in Omnibus needs special auditd logic
   - Deferred:
-    - `simp_options::fips`: GitLab Omnibus ships with a version of OpenSSL that
-      [does not support FIPS mode](https://gitlab.com/gitlab-org/omnibus-gitlab/-/issues/5574)
     - `simp_options::syslog` (not clear that we want to support this outside of `ee`)
   - SIMP integrations:
     - Open access for a local `git` SSH user
@@ -122,7 +120,7 @@ As a profile module, `simp_gitlab` has a few functions:
 
 #### Supported GitLab versions
 
-This module was last tested with GitLab Community Edition 13.11.5.
+This module was last tested with GitLab Community Edition 14.0.0.
 It may work for other GitLab versions. You can verify it works for a specific
 version by [executing the acceptance tests with that version](#acceptance-tests).
 
@@ -134,6 +132,14 @@ management are disabled from the module, and that the `gitlab-ce` or
 parameter is set to the correct edition.
 
 #### Upgrade caveats
+
+##### Upgrade to 0.7.0
+
+simp_gitlab version 0.7.0 now defaults `simp_gitlab::allow_fips` to true, as
+the version of GitLab this module was tested with, 14.0.0, supports FIPS mode.
+This will allow you to install and configure GitLab on FIPS_enabled servers,
+but not affect existing GitLab servers configured by earlier versions of this
+module.
 
 ##### Upgrade to 0.6.0
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -31,7 +31,7 @@
 
 ## Classes
 
-### `simp_gitlab`
+### <a name="simp_gitlab"></a>`simp_gitlab`
 
 Welcome to SIMP!
 
@@ -50,9 +50,42 @@ it can be used independently:
 
 #### Parameters
 
-The following parameters are available in the `simp_gitlab` class.
+The following parameters are available in the `simp_gitlab` class:
 
-##### `trusted_nets`
+* [`trusted_nets`](#trusted_nets)
+* [`denied_nets`](#denied_nets)
+* [`external_url`](#external_url)
+* [`tcp_listen_port`](#tcp_listen_port)
+* [`firewall`](#firewall)
+* [`pki`](#pki)
+* [`app_pki_external_source`](#app_pki_external_source)
+* [`app_pki_dir`](#app_pki_dir)
+* [`app_pki_key`](#app_pki_key)
+* [`app_pki_cert`](#app_pki_cert)
+* [`app_pki_ca`](#app_pki_ca)
+* [`edition`](#edition)
+* [`two_way_ssl_validation`](#two_way_ssl_validation)
+* [`ldap_verify_certificates`](#ldap_verify_certificates)
+* [`ssl_verify_depth`](#ssl_verify_depth)
+* [`ssl_protocols`](#ssl_protocols)
+* [`gitlab_options`](#gitlab_options)
+* [`cipher_suite`](#cipher_suite)
+* [`ldap`](#ldap)
+* [`ldap_uri`](#ldap_uri)
+* [`ldap_active_directory`](#ldap_active_directory)
+* [`ldap_base_dn`](#ldap_base_dn)
+* [`ldap_bind_dn`](#ldap_bind_dn)
+* [`ldap_bind_pw`](#ldap_bind_pw)
+* [`ldap_user_filter`](#ldap_user_filter)
+* [`ldap_group_base`](#ldap_group_base)
+* [`manage_package`](#manage_package)
+* [`package_ensure`](#package_ensure)
+* [`set_gitlab_root_password`](#set_gitlab_root_password)
+* [`gitlab_root_password`](#gitlab_root_password)
+* [`rails_console_load_timeout`](#rails_console_load_timeout)
+* [`allow_fips`](#allow_fips)
+
+##### <a name="trusted_nets"></a>`trusted_nets`
 
 Data type: `Simplib::Netlist`
 
@@ -60,7 +93,7 @@ A list of subnets (in CIDR notation) that should be permitted access
 
 Default value: `simplib::lookup('simp_options::trusted_nets', {'default_value' => ['127.0.0.1/32'] })`
 
-##### `denied_nets`
+##### <a name="denied_nets"></a>`denied_nets`
 
 Data type: `Simplib::Netlist`
 
@@ -68,7 +101,7 @@ A list of subnets (in CIDR notation) that should be explicitly denied access
 
 Default value: `[]`
 
-##### `external_url`
+##### <a name="external_url"></a>`external_url`
 
 Data type: `Simplib::Uri`
 
@@ -77,7 +110,7 @@ External URL of Gitlab.  By default, this will be 'https://<fqdn>' if
 
 Default value: `$pki`
 
-##### `tcp_listen_port`
+##### <a name="tcp_listen_port"></a>`tcp_listen_port`
 
 Data type: `Simplib::Port`
 
@@ -86,7 +119,7 @@ this will be ``'80'`` if HTTPS is disabled and ``'443'`` if HTTPS is enabled.
 
 Default value: `$pki`
 
-##### `firewall`
+##### <a name="firewall"></a>`firewall`
 
 Data type: `Boolean`
 
@@ -94,7 +127,7 @@ If ``true``, manage firewall rules to accommodate **simp_gitlab**
 
 Default value: `simplib::lookup('simp_options::firewall',      {'default_value' => false})`
 
-##### `pki`
+##### <a name="pki"></a>`pki`
 
 Data type: `Simp_gitlab::Stroolean`
 
@@ -112,7 +145,7 @@ Data type: `Simp_gitlab::Stroolean`
 
 Default value: `simplib::lookup('simp_options::pki', { 'default_value' => false })`
 
-##### `app_pki_external_source`
+##### <a name="app_pki_external_source"></a>`app_pki_external_source`
 
 Data type: `String`
 
@@ -123,7 +156,7 @@ Data type: `String`
 
 Default value: `simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' })`
 
-##### `app_pki_dir`
+##### <a name="app_pki_dir"></a>`app_pki_dir`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -132,7 +165,7 @@ This variable controls the basepath of ``$app_pki_key``, ``$app_pki_cert``,
 
 Default value: `'/etc/pki/simp_apps/gitlab/x509'`
 
-##### `app_pki_key`
+##### <a name="app_pki_key"></a>`app_pki_key`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -140,7 +173,7 @@ Full path of the private SSL key file.
 
 Default value: `"${app_pki_dir}/private/${facts['fqdn']}.pem"`
 
-##### `app_pki_cert`
+##### <a name="app_pki_cert"></a>`app_pki_cert`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -148,7 +181,7 @@ Full path of the public SSL certificate.
 
 Default value: `"${app_pki_dir}/public/${facts['fqdn']}.pub"`
 
-##### `app_pki_ca`
+##### <a name="app_pki_ca"></a>`app_pki_ca`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -156,7 +189,7 @@ Full path of the the SSL CA certificate.
 
 Default value: `"${app_pki_dir}/cacerts/cacerts.pem"`
 
-##### `edition`
+##### <a name="edition"></a>`edition`
 
 Data type: `Enum['ce','ee']`
 
@@ -164,7 +197,7 @@ The Gitlab Omnibus edition to install.
 
 Default value: `'ce'`
 
-##### `two_way_ssl_validation`
+##### <a name="two_way_ssl_validation"></a>`two_way_ssl_validation`
 
 Data type: `Boolean`
 
@@ -172,7 +205,7 @@ When ``true``, server and clients will require mutual TLS authentication.
 
 Default value: ``false``
 
-##### `ldap_verify_certificates`
+##### <a name="ldap_verify_certificates"></a>`ldap_verify_certificates`
 
 Data type: `Boolean`
 
@@ -181,7 +214,7 @@ CA.
 
 Default value: ``true``
 
-##### `ssl_verify_depth`
+##### <a name="ssl_verify_depth"></a>`ssl_verify_depth`
 
 Data type: `Integer[1]`
 
@@ -189,7 +222,7 @@ Sets the verification depth in the client certificates chain.
 
 Default value: `2`
 
-##### `ssl_protocols`
+##### <a name="ssl_protocols"></a>`ssl_protocols`
 
 Data type: `Array[String[1]]`
 
@@ -197,7 +230,7 @@ Array of Nginx-compatible SSL/TLS protocols for the web server to accept.
 
 Default value: `['TLSv1.2']`
 
-##### `gitlab_options`
+##### <a name="gitlab_options"></a>`gitlab_options`
 
 Data type: `Hash`
 
@@ -209,7 +242,7 @@ take precedence.
 
 Default value: `{}`
 
-##### `cipher_suite`
+##### <a name="cipher_suite"></a>`cipher_suite`
 
 Data type: `Array[String[1]]`
 
@@ -219,7 +252,7 @@ Default value: `simplib::lookup( 'simp_options::openssl::cipher_suite', {
                                                                         'default_value'  => ['DEFAULT', '!MEDIUM']
                                                                       })`
 
-##### `ldap`
+##### <a name="ldap"></a>`ldap`
 
 Data type: `Boolean`
 
@@ -227,7 +260,7 @@ If ``true``, enable LDAP support for Gitlab Omnibus.
 
 Default value: `simplib::lookup('simp_options::ldap',          {'default_value' => false})`
 
-##### `ldap_uri`
+##### <a name="ldap_uri"></a>`ldap_uri`
 
 Data type: `Array[Simplib::URI]`
 
@@ -236,7 +269,7 @@ List of OpenLDAP server URIs.  Note that _multiple_ URIs is an EE feature.
 
 Default value: `simplib::lookup('simp_options::ldap::uri',     {'default_value' => []})`
 
-##### `ldap_active_directory`
+##### <a name="ldap_active_directory"></a>`ldap_active_directory`
 
 Data type: `Boolean`
 
@@ -246,7 +279,7 @@ If your LDAP server is not AD, set this to false.
 
 Default value: ``false``
 
-##### `ldap_base_dn`
+##### <a name="ldap_base_dn"></a>`ldap_base_dn`
 
 Data type: `String[3]`
 
@@ -256,7 +289,7 @@ Base where we can search for users
 
 Default value: `simplib::lookup('simp_options::ldap::base_dn', {'default_value' => simplib::ldap::domain_to_dn()})`
 
-##### `ldap_bind_dn`
+##### <a name="ldap_bind_dn"></a>`ldap_bind_dn`
 
 Data type: `String[3]`
 
@@ -264,7 +297,7 @@ The DN to use when binding to the LDAP server
 
 Default value: `simplib::lookup('simp_options::ldap::bind_dn', {'default_value' => "cn=hostAuth,ou=Hosts,${ldap_base_dn}"})`
 
-##### `ldap_bind_pw`
+##### <a name="ldap_bind_pw"></a>`ldap_bind_pw`
 
 Data type: `String[1]`
 
@@ -272,7 +305,7 @@ The password of the bind user
 
 Default value: `simplib::lookup('simp_options::ldap::bind_pw', {'default_value' => "cn=LDAPAdmin,ou=People,${ldap_base_dn}"})`
 
-##### `ldap_user_filter`
+##### <a name="ldap_user_filter"></a>`ldap_user_filter`
 
 Data type: `Optional[String[1]]`
 
@@ -281,7 +314,7 @@ Format: RFC 4515 http://tools.ietf.org/search/rfc4515
 
 Default value: ``undef``
 
-##### `ldap_group_base`
+##### <a name="ldap_group_base"></a>`ldap_group_base`
 
 Data type: `Optional[String[3]]`
 
@@ -289,7 +322,7 @@ EE only
 
 Default value: ``undef``
 
-##### `manage_package`
+##### <a name="manage_package"></a>`manage_package`
 
 Data type: `Boolean`
 
@@ -297,7 +330,7 @@ Whether to manage the gitlab-[ce,ee] package.
 
 Default value: ``true``
 
-##### `package_ensure`
+##### <a name="package_ensure"></a>`package_ensure`
 
 Data type: `String`
 
@@ -306,7 +339,7 @@ The ensure status of the gitlab-[ce,ee] package, when managed by
 
 Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })`
 
-##### `set_gitlab_root_password`
+##### <a name="set_gitlab_root_password"></a>`set_gitlab_root_password`
 
 Data type: `Boolean`
 
@@ -318,7 +351,7 @@ Whether to set the GitLab root password.
 
 Default value: ``true``
 
-##### `gitlab_root_password`
+##### <a name="gitlab_root_password"></a>`gitlab_root_password`
 
 Data type: `String[16]`
 
@@ -328,7 +361,7 @@ GitLab root password to set.
 
 Default value: `simplib::passgen( "simp_gitlab_${trusted['certname']}" )`
 
-##### `rails_console_load_timeout`
+##### <a name="rails_console_load_timeout"></a>`rails_console_load_timeout`
 
 Data type: `Integer[60]`
 
@@ -337,7 +370,7 @@ setting the GitLab root password.
 
 Default value: `300`
 
-##### `allow_fips`
+##### <a name="allow_fips"></a>`allow_fips`
 
 Data type: `Boolean`
 
@@ -347,11 +380,11 @@ server has FIPS enabled.
 * Only set this to `true` if the version of GitLab you are running
   supports FIPS mode.
 
-Default value: ``false``
+Default value: ``true``
 
 ## Functions
 
-### `simp_gitlab::omnibus_config::gitlab`
+### <a name="simp_gitlabomnibus_configgitlab"></a>`simp_gitlab::omnibus_config::gitlab`
 
 Type: Puppet Language
 
@@ -365,7 +398,7 @@ settings
 
 Returns: `Any` Hash of `puppet/gitlab` parameters
 
-### `simp_gitlab::omnibus_config::gitlab_rails`
+### <a name="simp_gitlabomnibus_configgitlab_rails"></a>`simp_gitlab::omnibus_config::gitlab_rails`
 
 Type: Puppet Language
 
@@ -379,7 +412,7 @@ SIMP settings
 
 Returns: `Any` Hash of settings for the 'gitlab::gitlab_rails' # parameter
 
-### `simp_gitlab::omnibus_config::gitlab_shell`
+### <a name="simp_gitlabomnibus_configgitlab_shell"></a>`simp_gitlab::omnibus_config::gitlab_shell`
 
 Type: Puppet Language
 
@@ -393,7 +426,7 @@ SIMP settings
 
 Returns: `Any` Hash of settings for the 'gitlab::shell' parameter
 
-### `simp_gitlab::omnibus_config::mattermost`
+### <a name="simp_gitlabomnibus_configmattermost"></a>`simp_gitlab::omnibus_config::mattermost`
 
 Type: Puppet Language
 
@@ -407,7 +440,7 @@ SIMP settings
 
 Returns: `Any` Hash of settings for the 'gitlab::mattermost' parameter
 
-### `simp_gitlab::omnibus_config::nginx`
+### <a name="simp_gitlabomnibus_confignginx"></a>`simp_gitlab::omnibus_config::nginx`
 
 Type: Puppet Language
 
@@ -423,9 +456,13 @@ Returns: `Any` Hash of settings for the 'gitlab::nginx' parameter
 
 ## Data types
 
-### `Simp_Gitlab::Stroolean`
+### <a name="simp_gitlabstroolean"></a>`Simp_Gitlab::Stroolean`
 
 Valid PKI management options
 
-Alias of `Variant[Enum['simp'], Boolean]`
+Alias of
+
+```puppet
+Variant[Enum['simp'], Boolean]
+```
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -186,7 +186,7 @@ class simp_gitlab (
   Boolean                $set_gitlab_root_password   = true,
   String[16]             $gitlab_root_password       = simplib::passgen( "simp_gitlab_${trusted['certname']}" ),
   Integer[60]            $rails_console_load_timeout = 300,
-  Boolean                $allow_fips                 = false
+  Boolean                $allow_fips                 = true
 ) {
 
   simplib::assert_metadata( $module_name )

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -251,14 +251,14 @@ describe 'simp_gitlab' do
         context 'with default parameters' do
           let(:params) {{ }}
 
-          it { is_expected.to_not compile.with_all_deps }
-        end
-
-        context 'with allow_fips=true' do
-          let(:params) {{ :allow_fips => true }}
-
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_class('simp_gitlab').with_trusted_nets(['127.0.0.1/32']) }
+        end
+
+        context 'with allow_fips=false' do
+          let(:params) {{ :allow_fips => false }}
+
+          it { is_expected.to_not compile.with_all_deps }
         end
       end
 


### PR DESCRIPTION
Changed:
- Updated the latest tested version of GitLab CE to 14.0.0.
- `simp_gitlab::allow_fips` now defaults to true, as the last version of
  GitLab this module was tested with, 14.0.0, supports FIPS mode.
  - This will allow you to install and configure GitLab on FIPS-enabled
    servers, but not affect existing GitLab servers configured by earlier
    versions of this module.

Maintentance:
- Added acceptance test job for Puppet 7

[SIMP-9747] #close

[SIMP-9747]: https://simp-project.atlassian.net/browse/SIMP-9747