### PR TITLE
(SIMP-9740) Update simp_gitlab acceptance test to use 389ds LDAP server

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,6 +6,7 @@ fixtures:
     augeasproviders_ssh: https://github.com/simp/augeasproviders_ssh.git
     chrony: https://github.com/simp/pupmod-voxpupuli-chrony.git
     concat: https://github.com/simp/puppetlabs-concat.git
+    ds389: https://github.com/simp/pupmod-simp-ds389.git
     firewalld: https://github.com/simp/pupmod-voxpupuli-firewalld.git
     gitlab: https://github.com/simp/puppet-gitlab.git
     iptables: https://github.com/simp/pupmod-simp-iptables.git
@@ -15,6 +16,7 @@ fixtures:
     rsyslog: https://github.com/simp/pupmod-simp-rsyslog.git
     ssh: https://github.com/simp/pupmod-simp-ssh.git
     simplib: https://github.com/simp/pupmod-simp-simplib.git
+    simp_ds389: https://github.com/simp/pupmod-simp-simp_ds389.git
     simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld.git
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
     svckill: https://github.com/simp/pupmod-simp-svckill.git

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   * [Configuring Nginx](#configuring-nginx)
 * [Reference](#reference)
   * [Further Reference for munging GitLab Omnibus](#further-reference-for-munging-gitlab-omnibus)
+  * [GitLab LDAP integration reference](#gitlab-ldap-integration-reference)
 * [Limitations](#limitations)
   * [SIMP PKI management does not support Let's Encrypt](#simp-pki-management-does-not-support-lets-encrypt)
   * [Gitlab's LDAP TLS is configured to re-use Omnibus' `trusted-certs/` instead of `ca_file`](#gitlabs-ldap-tls-is-configured-to-re-use-omnibus-trusted-certs-instead-of-ca_file)
@@ -238,7 +239,7 @@ See [REFERENCE.md](./REFERENCE.md) for API documentation.
   * GitLab Omnibus
     - documentation: https://docs.gitlab.com/omnibus/README.html
       - [Common installation problems](https://docs.gitlab.com/omnibus/common_installation_problems/README.html)
-      - [Maintainence commands](https://docs.gitlab.com/omnibus/maintenance/README.html#maintenance-commands)
+      - [Maintenance commands](https://docs.gitlab.com/omnibus/maintenance/README.html#maintenance-commands)
       - [Troubleshooting](https://docs.gitlab.com/omnibus/README.html#troubleshooting)
     - architecture: https://docs.gitlab.com/omnibus/architecture/README.html
       - [Global GitLab configuration template](https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/files/gitlab-config-template/gitlab.rb.template)
@@ -254,6 +255,15 @@ See [REFERENCE.md](./REFERENCE.md) for API documentation.
   - Security & compliance
     - https://www.stigviewer.com/stig/web_server/
 
+### GitLab LDAP integration reference
+
+[GitLab LDAP Setup](https://docs.gitlab.com/ee/administration/auth/ldap) has
+detailed information about configuring GitLab to authenticate users using LDAP.
+Within this section, there are two sub-sections especially of interest when
+debugging LDAP connection problems:
+
+  * [LDAP TLS limitations](https://docs.gitlab.com/ee/administration/auth/ldap/#limitations)
+  * [LDAP troubleshooting](https://docs.gitlab.com/ee/administration/auth/ldap/#troubleshooting)
 
 ## Limitations
 

--- a/spec/acceptance/nodesets/centos-8-x86_64.yml
+++ b/spec/acceptance/nodesets/centos-8-x86_64.yml
@@ -51,17 +51,17 @@ HOSTS:
     hypervisor: <%= hypervisor %>
     vagrant_memsize: 256
 
-# Until SIMP 6.6.0, LDAP server must be on an EL7 node
   client-2:
     roles:
       - client
       - unknownclient
       - logdest
       - ldapserver
-    platform:   el-7-x86_64
-    box:        centos/7
+    platform:   el-8-x86_64
+    box:        generic/centos8
     hypervisor: <%= hypervisor %>
-    vagrant_memsize: 512
+    vagrant_memsize: 2048
+
 CONFIG:
   log_level: verbose
   type:      aio

--- a/spec/acceptance/nodesets/oel-8-x86_64.yml
+++ b/spec/acceptance/nodesets/oel-8-x86_64.yml
@@ -51,17 +51,17 @@ HOSTS:
     hypervisor: <%= hypervisor %>
     vagrant_memsize: 256
 
-# Until SIMP 6.6.0, LDAP server must be on an EL7 node
   client-2:
     roles:
       - client
       - unknownclient
       - logdest
       - ldapserver
-    platform:   el-7-x86_64
-    box:        generic/oracle7
+    platform:   el-8-x86_64
+    box:        generic/oracle8
     hypervisor: <%= hypervisor %>
-    vagrant_memsize: 512
+    vagrant_memsize: 2048
+
 CONFIG:
   log_level: verbose
   type:      aio

--- a/spec/acceptance/suites/default/00_pki_spec.rb
+++ b/spec/acceptance/suites/default/00_pki_spec.rb
@@ -60,6 +60,17 @@ describe 'simp_gitlab pki tls' do
     EOS
   end
 
+  # workaround beaker issue in which FQDN is not properly set but Facter
+  # thinks it is set
+  context 'fix static host name' do
+    hosts.each do |host|
+      it "should ensure static host name matches FQDN fact on #{host}" do
+        fqdn = fact_on(host, 'fqdn')
+        on(host, "hostnamectl set-hostname --static #{fqdn}")
+      end
+    end
+  end
+
   context 'with PKI enabled but no firewall' do
     let(:hiera) {
       hiera = hiera__vagrant.dup

--- a/spec/acceptance/suites/default/support/files/add_ldapusers.sh
+++ b/spec/acceptance/suites/default/support/files/add_ldapusers.sh
@@ -1,0 +1,29 @@
+# This script creates users and groups needed to test GitLab's LDAP configuration.
+# Requires token substitution for LDAP_BASE_DN.
+
+# ------------------------------------------------------------------------------
+# gitlab group for users that are allowed to log into gitlab
+# ------------------------------------------------------------------------------
+dsidm "accounts" -b "LDAP_BASE_DN" posixgroup create --cn gitlab --gidNumber 19999
+
+# ------------------------------------------------------------------------------
+# ldapuser1 should be able to log into gitlab, because belongs to gitlab group
+# ------------------------------------------------------------------------------
+dsidm "accounts" -b "LDAP_BASE_DN" posixgroup create --cn ldapuser1 --gidNumber 10001
+dsidm "accounts" -b "LDAP_BASE_DN" user create --cn ldapuser1 --uid ldapuser1 --displayName "Test user 1" --uidNumber 10001 --gidNumber 10001 --homeDirectory /home/ldapuser1
+
+#suP3rP@ssw0r!
+dsidm "accounts" -b "LDAP_BASE_DN" user modify ldapuser1 add:userPassword:{SSHA}r2GaizHFWY8pcHpIClU0ye7vsO4uHv/y
+
+dsidm "accounts" -b "LDAP_BASE_DN" posixgroup modify gitlab add:member:uid=ldapuser1,ou=People,LDAP_BASE_DN
+
+
+# ------------------------------------------------------------------------------
+# ldapuser2 should not be able to log into gitlab, because does *not* belong to
+# gitlab group
+# ------------------------------------------------------------------------------
+dsidm "accounts" -b "LDAP_BASE_DN" posixgroup create --cn ldapuser2 --gidNumber 10002
+dsidm "accounts" -b "LDAP_BASE_DN" user create --cn ldapuser2 --uid ldapuser2 --displayName "Test User" --uidNumber 10002 --gidNumber 10002 --homeDirectory /home/ldapuser2
+
+#suP3rP@ssw0r!
+dsidm "accounts" -b "LDAP_BASE_DN" user modify ldapuser2 add:userPassword:{SSHA}r2GaizHFWY8pcHpIClU0ye7vsO4uHv/y

--- a/spec/acceptance/suites/default/support/files/ldap_test_user.ldif
+++ b/spec/acceptance/suites/default/support/files/ldap_test_user.ldif
@@ -1,4 +1,5 @@
 # This LDIF creates users and groups needed to test GitLab's LDAP configuration
+# Requires token substitution for LDAP_BASE_DN.
 
 # ------------------------------------------------------------------------------
 # ldapuser1 should be able to log into gitlab
@@ -56,12 +57,6 @@ objectClass: ldapPublicKey
 loginShell: /bin/bash
 homeDirectory: /home/ldapuser2
 
-
-
-
-# ------------------------------------------------------------------------------
-# (As of 10.4) LDAP group membership is only considered by GitLab EE
-# ------------------------------------------------------------------------------
 dn: cn=gitlab,ou=Group,LDAP_BASE_DN
 objectClass: posixGroup
 objectClass: top
@@ -73,4 +68,3 @@ dn: cn=gitlab,ou=Group,LDAP_BASE_DN
 changetype: modify
 add: memberUid
 memberUid: ldapuser1
-

--- a/spec/acceptance/suites/default/support/files/ldap_tls_default.yaml
+++ b/spec/acceptance/suites/default/support/files/ldap_tls_default.yaml
@@ -51,16 +51,7 @@ simp_ds389::instances::accounts::password_policy:
   passwordMaxFailure: 100
 
 
-# FIXME Workarounds
-# * SIMP-10378: GitLab does not support TLS client authentication but
-#   simp_ds389::instances::accounts requires it.
-# * GitLab LDAP client sends lower ciphers than the minssf default of 256
-#   - Reported connection is TLS1.2 128-bit AES-GCM
-#   - Longer (better) ciphers are available in the configured cipher set
-#    (openssl "DEFAULT:!MEDIUM"), so it is unclear why none of the ciphers
-#    that would satisfy 256 minssf are agreed upon when GitLab and 389ds
-#    negotiate them during TLS setup.
-#
+# GitLab - 389ds interoperability settings
 simp_ds389::instances::accounts::tls_params:
   dse_config:
     cn=config:

--- a/spec/acceptance/suites/default/support/files/ldap_tls_default.yaml
+++ b/spec/acceptance/suites/default/support/files/ldap_tls_default.yaml
@@ -1,7 +1,17 @@
 ---
+# Test hieradata for LDAP
+# - Requires token substitution for LDAP_URI and LDAP_BASE_DN
+# - When using TLS (not StartTLS), requires replacement of 'ldap:' with
+#   'ldaps:' in URLs
+# - None of the test manifests actually incude the simp_options class. However,
+#   we are setting some of its global catalysts, here, because it simplifies
+#   the configuration of multiple classes
+
+###############################################################################
+# Common security settings
+###############################################################################
+simp_options::firewall: true
 simp_options::trusted_nets:   ['any']
-simp_options::puppet::server: there.is.no.puppet.server
-simp_options::puppet::ca:     there.is.no.puppet.ca
 simp_options::pki:            true
 simp_options::pki::source:    '/etc/pki/simp-testing/pki'
 
@@ -10,13 +20,18 @@ pki::public_key_source:  "/etc/pki/simp-testing/pki/public/%{facts.fqdn}.pub"
 pki::cacerts_sources:
   - "/etc/pki/simp-testing/pki/cacerts"
 
+# When iptables is enabled, make sure it uses firewalld on EL7
+iptables::use_firewalld: true
+
+###############################################################################
+# Common LDAP settings
+###############################################################################
 simp_options::ldap: true
 simp_options::ldap::uri:
   - ldap://LDAP_URI
 simp_options::ldap::base_dn:  LDAP_BASE_DN
 simp_options::ldap::bind_dn:  cn=hostAuth,ou=Hosts,LDAP_BASE_DN
 simp_options::ldap::bind_pw: 'foobarbaz'
-# suP3rP@ssw0r!
 simp_options::ldap::bind_hash: '{SSHA}BNPDR0qqE6HyLTSlg13T0e/+yZnSgYQz'
 simp_options::ldap::sync_pw: 'foobarbaz'
 simp_options::ldap::sync_hash: '{SSHA}BNPDR0qqE6HyLTSlg13T0e/+yZnSgYQz'
@@ -24,19 +39,53 @@ simp_options::ldap::master:  ldap://LDAP_URI
 simp_options::ldap::root_dn: cn=LDAPAdmin,ou=People,LDAP_BASE_DN
 
 
+###############################################################################
+# simp_ds389::instances::accounts settings only applicable on EL8+
+###############################################################################
+simp_ds389::instances::accounts::root_pw: 'suP3rP@ssw0r!'
 
-simp_openldap::app_pki_dir: /etc/pki/simp_apps/openldap/x509
-simp_openldap::app_pki_external_source: /etc/pki/simp-testing/pki
+# relaxed LDAP defaults to make multiple tests easier to mock
+simp_ds389::instances::accounts::password_policy:
+  passwordMustChange: 'off'
+  passwordMinLength: 3
+  passwordMaxFailure: 100
+
+
+# FIXME Workarounds
+# * SIMP-10378: GitLab does not support TLS client authentication but
+#   simp_ds389::instances::accounts requires it.
+# * GitLab LDAP client sends lower ciphers than the minssf default of 256
+#   - Reported connection is TLS1.2 128-bit AES-GCM
+#   - Longer (better) ciphers are available in the configured cipher set
+#    (openssl "DEFAULT:!MEDIUM"), so it is unclear why none of the ciphers
+#    that would satisfy 256 minssf are agreed upon when GitLab and 389ds
+#    negotiate them during TLS setup.
+#
+simp_ds389::instances::accounts::tls_params:
+  dse_config:
+    cn=config:
+      nsslapd-minssf: 128
+    cn=encryption,cn=config:
+      nsSSLClientAuth: allowed
+
+###############################################################################
+# simp_openldap::client settings only applicable on EL7
+# - Used when adding ldapuser1 & ldapuser2 using 'ldapadd'
+###############################################################################
+simp_openldap::client::tls_cipher_suite:
+- 'HIGH'
+- '-SSLv2'
+
+###############################################################################
+# simp_openldap::server settings only applicable on EL7
+###############################################################################
 simp_openldap::server::conf::rootpw: "{SSHA}TghZyHW6r8/NL4fo0Q8BnihxVb7A7af5"
 simp_openldap::server::use_ppolicy: true
 simp_openldap::server::conf::tls_cipher_suite:
 - 'HIGH'
 - '-SSLv2'
-simp_openldap::server::conf::tls_protocol_min: 3.3
 
-simp_openldap::client::tls_cipher_suite:
-- 'HIGH'
-- '-SSLv2'
+simp_openldap::server::conf::tls_protocol_min: 3.3
 simp_openldap::server::conf::slapd_log_level:
 - 'stats'
 - 'sync'
@@ -50,7 +99,9 @@ simp_openldap::server::conf::default_ldif::ppolicy_pwd_min_length: 3
 simp_openldap::server::conf::default_ldif::ppolicy_pwd_check_quality: 0
 simp_openldap::server::conf::default_ldif::ppolicy_pwd_max_failure: 100
 
-# allow vagrant access
+###############################################################################
+# Settings to allow vagrant access
+###############################################################################
 sudo::user_specifications:
   vagrant_all:
     user_list:
@@ -58,16 +109,13 @@ sudo::user_specifications:
     cmnd:
       - 'ALL'
     passwd: false
+
 pam::access::users:
   defaults:
     origins:
       - 'ALL'
     permission: '+'
   vagrant:
+
 ssh::server::conf::permitrootlogin: true
 ssh::server::conf::authorizedkeysfile: '.ssh/authorized_keys'
-
-
-# when iptables is enabled, make sure it uses firewalld
-iptables::use_firewalld: true
-

--- a/spec/acceptance/suites/default/support/manifests/install_ldap_server.pp
+++ b/spec/acceptance/suites/default/support/manifests/install_ldap_server.pp
@@ -1,15 +1,17 @@
-# NOTE: The design of the simp_openldap module requires most configuration
-#       to be handled from hiera
-class{'simp_openldap': is_server => true }
+# NOTE: The LDAP server and client configurations are largely handled from hiera
+
+if $facts['os']['release']['major'] == '7' {
+  # Sets up server and client
+  class{'simp_openldap': is_server => true }
+}
+else {
+  # Sets up LDAP server, only.
+  include 'simp_ds389::instances::accounts'
+}
+
 include 'svckill'
 include 'iptables'
-
 iptables::listen::tcp_stateful { 'ssh':
   dports       => 22,
   trusted_nets => ['any'],
 }
-iptables::listen::tcp_stateful { 'ldaps':
-  dports       => [389,636],
-  trusted_nets => ['any'],
-}
-

--- a/spec/acceptance/suites/default/support/manifests/remove_ldap_server.pp
+++ b/spec/acceptance/suites/default/support/manifests/remove_ldap_server.pp
@@ -1,0 +1,18 @@
+# NOTE: The LDAP server configuration largely handled from hiera
+
+if $facts['os']['release']['major'] == '7' {
+  service { 'slapd': ensure => 'stopped' }
+
+  $ldap_packages = [ 'openldap-servers', 'openldap-clients' ]
+  package { $ldap_packages: ensure => absent, require => Service['slapd'] }
+
+  $ldap_dirs = [ '/var/lib/ldap', '/etc/openldap' ]
+  tidy { $ldap_dirs:
+    recurse => true,
+    rmdirs  => true,
+    require => Service['slapd']
+  }
+}
+else {
+  ds389::instance { 'accounts': ensure => 'absent' }
+}


### PR DESCRIPTION
- Maintenance
  - Test with simp_ds38d::instances::accounts LDAP server in the CentOS8 and
    OEL8 nodesets
  - Includes workaround for SIMP-10378
  - Includes workaround for minimum SSF issue, whereby the ciphers
    negotiated between the GitLab LDAP client and the 389ds server
    result in a SSF mismatch

SIMP-9740 #close