### PR TITLE
Dependency Updates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Fri Jun 03 2022 Trevor Vaughan <trevor@sicura.us> - 0.7.1
+- Allow `puppet/chrony` < `3.0.0`
+- Allow `puppet/gitlab` < `9.0.0`
+- Allow `puppetlabs/stdlib` < `9.0.0`
+- Bump latest tested GitLab CE version to 15.0.1
+
 * Tue Jun 22 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.7.0
 - Removed
   - Dropped support for Puppet 5

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@
 * [Setup](#setup)
   * [What `simp_gitlab` affects](#what-simp_gitlab-affects)
   * [Setup Requirements](#setup-requirements)
+    * [Supported GitLab versions](#supported-gitlab-versions)
+    * [Isolated network requirements](#isolated-network-requirements)
+    * [Upgrade caveats](#upgrade-caveats)
+      * [Upgrade to 0.7.0](#upgrade-to-070)
+      * [Upgrade to 0.6.0](#upgrade-to-060)
+      * [Upgrade to 0.3.0](#upgrade-to-030)
   * [Beginning with simp_gitlab](#beginning-with-simp_gitlab)
 * [Usage](#usage)
   * [A basic GitLab setup using PKI](#a-basic-gitlab-setup-using-pki)
@@ -121,7 +127,7 @@ As a profile module, `simp_gitlab` has a few functions:
 
 #### Supported GitLab versions
 
-This module was last tested with GitLab Community Edition 14.0.0.
+This module was last tested with GitLab Community Edition 15.0.1.
 It may work for other GitLab versions. You can verify it works for a specific
 version by [executing the acceptance tests with that version](#acceptance-tests).
 
@@ -379,7 +385,7 @@ package version or 'latest' to indicate the latest available version.
 When unset, the latest version is tested.
 
 ```shell
-TEST_GITLAB_CE_VERSION=13.11.5 bundle exec rake beaker:suites
+TEST_GITLAB_CE_VERSION=15.0.1 bundle exec rake beaker:suites
 ```
 
 #### Environment variable `TRUSTED_NETS`

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_gitlab",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": "SIMP Team",
   "summary": "SIMP profiles for GitLab",
   "license": "Apache-2.0",
@@ -17,7 +17,7 @@
   "dependencies": [
     {
       "name": "puppet/chrony",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 1.0.0 < 3.0.0"
     },
     {
       "name": "herculesteam/augeasproviders_ssh",
@@ -25,11 +25,11 @@
     },
     {
       "name": "puppet/gitlab",
-      "version_requirement": ">= 6.0.1 < 8.0.0"
+      "version_requirement": ">= 6.0.1 < 9.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.6.0 < 8.0.0"
+      "version_requirement": ">= 6.6.0 < 9.0.0"
     },
     {
       "name": "simp/iptables",


### PR DESCRIPTION
- Allow `puppet/chrony` < `3.0.0`
- Allow `puppet/gitlab` < `9.0.0`
- Allow `puppetlabs/stdlib` < `9.0.0`
- Bump latest tested GitLab CE version to 15.0.1

Closes #65
