### PR TITLE
Removes puppet 6 from .gitlab-ci.yml

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -27,7 +27,7 @@ on:
     types: [opened, reopened, synchronize]
 
 env:
-  PUPPET_VERSION: '~> 6'
+  PUPPET_VERSION: '~> 7'
 
 jobs:
   puppet-syntax:
@@ -38,7 +38,7 @@ jobs:
       - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
         uses: ruby/setup-ruby@v1  # ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: "bundle exec rake syntax"
 
@@ -50,7 +50,7 @@ jobs:
       - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: "bundle exec rake lint"
       - run: "bundle exec rake metadata_lint"
@@ -65,7 +65,7 @@ jobs:
       - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: |
           bundle show
@@ -76,10 +76,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: 'Install Ruby 2.5'
+      - name: 'Install Ruby 2.7'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: bundle exec rake check:dot_underscore
       - run: bundle exec rake check:test_file
@@ -92,7 +92,7 @@ jobs:
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - name: 'Tags and changelogs'
         run: |
@@ -109,12 +109,12 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 6.22 [SIMP 6.6/PE 2019.8]'
-            puppet_version: '~> 6.22.1'
-            ruby_version: '2.5'
           - label: 'Puppet 7.x'
-            puppet_version: '~> 7.0'
+            puppet_version: '~> 7.21.0'
             ruby_version: '2.7'
+          - label: 'Puppet 8.x'
+            puppet_version: '~> 8.0'
+            ruby_version: '3.2'
     env:
       PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -232,26 +232,26 @@ variables:
 # Puppet Versions
 #-----------------------------------------------------------------------
 
-.pup_6_x: &pup_6_x
-  image: 'ruby:2.5'
-  variables:
-    PUPPET_VERSION: '~> 6.0'
-    BEAKER_PUPPET_COLLECTION: 'puppet6'
-    MATRIX_RUBY_VERSION: '2.5'
-
-.pup_6_pe: &pup_6_pe
-  image: 'ruby:2.5'
-  variables:
-    PUPPET_VERSION: '6.22.1'
-    BEAKER_PUPPET_COLLECTION: 'puppet6'
-    MATRIX_RUBY_VERSION: '2.5'
-
 .pup_7_x: &pup_7_x
   image: 'ruby:2.7'
   variables:
     PUPPET_VERSION: '~> 7.0'
     BEAKER_PUPPET_COLLECTION: 'puppet7'
     MATRIX_RUBY_VERSION: '2.7'
+
+.pup_7_pe: &pup_7_pe
+  image: 'ruby:2.7'
+  variables:
+    PUPPET_VERSION: '7.21.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet7'
+    MATRIX_RUBY_VERSION: '2.7'
+
+.pup_8_x: &pup_8_x
+  image: 'ruby:3.2'
+  variables:
+    PUPPET_VERSION: '~> 8.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet8'
+    MATRIX_RUBY_VERSION: '3.2'
 
 
 
@@ -302,7 +302,7 @@ variables:
 #=======================================================================
 
 releng_checks:
-  <<: *pup_6_x
+  <<: *pup_7_x
   <<: *setup_bundler_env
   stage: 'validation'
   tags: ['docker']
@@ -325,23 +325,23 @@ releng_checks:
 #       different Puppet versions won't accomplish anything.
 
 pup-lint:
-  <<: *pup_6_x
+  <<: *pup_7_x
   <<: *lint_tests
 
 # Unit Tests
 #-----------------------------------------------------------------------
 
-pup6.x-unit:
-  <<: *pup_6_x
+pup7.x-unit:
+  <<: *pup_7_x
   <<: *unit_tests
   <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
-pup6.pe-unit:
-  <<: *pup_6_pe
+pup7.pe-unit:
+  <<: *pup_7_pe
   <<: *unit_tests
 
-pup7.x-unit:
-  <<: *pup_7_x
+pup8.x-unit:
+  <<: *pup_8_x
   <<: *unit_tests
 
 # ------------------------------------------------------------------------------
@@ -357,8 +357,8 @@ pup7.x-unit:
 # Test with the GitLab latest version with the latest OS.  It may fail (i.e., we
 # have seen breaking changes on minor GitLab releases), but we want to try it
 # every time to have an early-warning of problems.
-pup6.x-el8-latest:
-  <<: *pup_6_x
+pup7.x-el8-latest:
+  <<: *pup_7_x
   <<: *acceptance_base
   allow_failure: true
   script:
@@ -370,59 +370,59 @@ pup6.x-el8-latest:
 # - Last stable GitLab version = 14.0.0
 # - **If you change this, also change the version in the README.md**.
 #
-pup6.x-el7-stable:
-  <<: *pup_6_x
+pup7.x-el7-stable:
+  <<: *pup_7_x
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
     - 'TEST_GITLAB_CE_VERSION=14.0.0 bundle exec rake beaker:suites[default,centos-7-x86_64]'
 
-pup6.x-el8-stable:
-  <<: *pup_6_x
+pup7.x-el8-stable:
+  <<: *pup_7_x
   <<: *acceptance_base
   script:
     - 'TEST_GITLAB_CE_VERSION=14.0.0 bundle exec rake beaker:suites[default,centos-8-x86_64]'
 
-pup6.x-el8-fips-stable:
-  <<: *pup_6_x
+pup7.x-el8-fips-stable:
+  <<: *pup_7_x
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
     - 'BEAKER_fips=yes TEST_GITLAB_CE_VERSION=14.0.0 bundle exec rake beaker:suites[default,centos-8-x86_64]'
 
-pup6.pe-el7-stable:
-  <<: *pup_6_pe
+pup7.pe-el7-stable:
+  <<: *pup_7_pe
   <<: *acceptance_base
   script:
     - 'TEST_GITLAB_CE_VERSION=14.0.0 bundle exec rake beaker:suites[default,centos-7-x86_64]'
 
-pup6.pe-el8-stable:
-  <<: *pup_6_pe
+pup7.pe-el8-stable:
+  <<: *pup_7_pe
   <<: *acceptance_base
   script:
     - 'TEST_GITLAB_CE_VERSION=14.0.0 bundle exec rake beaker:suites[default,centos-8-x86_64]'
 
-pup6.pe-el8-fips-stable:
-  <<: *pup_6_pe
+pup7.pe-el8-fips-stable:
+  <<: *pup_7_pe
   <<: *acceptance_base
   script:
     - 'BEAKER_fips=yes TEST_GITLAB_CE_VERSION=14.0.0 bundle exec rake beaker:suites[default,centos-8-x86_64]'
 
-pup6.pe-oel7-stable:
-  <<: *pup_6_pe
+pup7.pe-oel7-stable:
+  <<: *pup_7_pe
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
     - 'TEST_GITLAB_CE_VERSION=14.0.0 bundle exec rake beaker:suites[default,oel-7-x86_64]'
 
-pup6.pe-oel8-stable:
-  <<: *pup_6_pe
+pup7.pe-oel8-stable:
+  <<: *pup_7_pe
   <<: *acceptance_base
   script:
     - 'TEST_GITLAB_CE_VERSION=14.0.0 bundle exec rake beaker:suites[default,oel-8-x86_64]'
 
-pup7.x-el8-stable:
-  <<: *pup_7_x
+pup8.x-el8-stable:
+  <<: *pup_8_x
   <<: *acceptance_base
   script:
     - 'TEST_GITLAB_CE_VERSION=14.0.0 bundle exec rake beaker:suites[default,centos-8-x86_64]'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  puppet_version = ENV['PUPPET_VERSION'] || '~> 6.22'
+  puppet_version = ENV['PUPPET_VERSION'] || '~> 7'
   major_puppet_version = puppet_version.scan(/(\d+)(?:\.|\Z)/).flatten.first.to_i
   gem 'rake'
   gem 'puppet', puppet_version

--- a/spec/acceptance/nodesets/centos-7-x86_64.yml
+++ b/spec/acceptance/nodesets/centos-7-x86_64.yml
@@ -12,32 +12,6 @@ HOSTS:
     vagrant_cpus: 4
     family: centos-cloud/centos-7
     gce_machine_type: n1-standard-2
-#-------------------------------------------------------------------------------
-# If you want to use a web browser to manually inspect the SUT GitLab server
-# during any of the tests, uncomment the section below and add your host's
-# (non-local) IP address to the `TRUSTED_NETS` environment variable before
-# running beaker.
-#
-# See README.md for more details and environment variables
-#-------------------------------------------------------------------------------
-#    forwarded_ports:
-#      nginx_http:
-#        from: 8080
-#        to: 80
-#        from_ip: '127.0.0.1'
-#        to_ip: '0.0.0.0'
-#      nginx_https:
-#        from: 8443
-#        to: 443
-#        from_ip: '127.0.0.1'
-#        to_ip: '0.0.0.0'
-#      nginx_777:
-#        from: 8777
-#        to: 777
-#        from_ip: '127.0.0.1'
-#        to_ip: '0.0.0.0'
-#-------------------------------------------------------------------------------
-
   client-1:
     roles:
     - client

--- a/spec/acceptance/nodesets/centos-8-x86_64.yml
+++ b/spec/acceptance/nodesets/centos-8-x86_64.yml
@@ -12,32 +12,6 @@ HOSTS:
     vagrant_cpus: 4
     family: centos-cloud/centos-stream-8
     gce_machine_type: n1-standard-2
-#-------------------------------------------------------------------------------
-# If you want to use a web browser to manually inspect the SUT GitLab server
-# during any of the tests, uncomment the section below and add your host's
-# (non-local) IP address to the `TRUSTED_NETS` environment variable before
-# running beaker.
-#
-# See README.md for more details and environment variables
-#-------------------------------------------------------------------------------
-#    forwarded_ports:
-#      nginx_http:
-#        from: 8080
-#        to: 80
-#        from_ip: '127.0.0.1'
-#        to_ip: '0.0.0.0'
-#      nginx_https:
-#        from: 8443
-#        to: 443
-#        from_ip: '127.0.0.1'
-#        to_ip: '0.0.0.0'
-#      nginx_777:
-#        from: 8777
-#        to: 777
-#        from_ip: '127.0.0.1'
-#        to_ip: '0.0.0.0'
-#-------------------------------------------------------------------------------
-
   client-1:
     roles:
     - client

--- a/spec/acceptance/nodesets/oel-7-x86_64.yml
+++ b/spec/acceptance/nodesets/oel-7-x86_64.yml
@@ -1,76 +1,47 @@
-<%
-  if ENV['BEAKER_HYPERVISOR']
-    hypervisor = ENV['BEAKER_HYPERVISOR']
-  else
-    hypervisor = 'vagrant'
-  end
--%>
 ---
 HOSTS:
   server:
     roles:
-      - server
-      - default
-      - master
-    platform:   el-7-x86_64
-    box:        generic/oracle7
-    hypervisor: <%= hypervisor %>
+    - server
+    - default
+    - master
+    platform: el-7-x86_64
+    box: generic/oracle7
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
     vagrant_memsize: 4096
     vagrant_cpus: 4
-#-------------------------------------------------------------------------------
-# If you want to use a web browser to manually inspect the SUT GitLab server
-# during any of the tests, uncomment the section below and add your host's
-# (non-local) IP address to the `TRUSTED_NETS` environment variable before
-# running beaker.
-#
-# See README.md for more details and environment variables
-#-------------------------------------------------------------------------------
-#    forwarded_ports:
-#      nginx_http:
-#        from: 8080
-#        to: 80
-#        from_ip: '127.0.0.1'
-#        to_ip: '0.0.0.0'
-#      nginx_https:
-#        from: 8443
-#        to: 443
-#        from_ip: '127.0.0.1'
-#        to_ip: '0.0.0.0'
-#      nginx_777:
-#        from: 8777
-#        to: 777
-#        from_ip: '127.0.0.1'
-#        to_ip: '0.0.0.0'
-#-------------------------------------------------------------------------------
+    family: sicura-image-build/oracle-linux-7
+    gce_machine_type: n1-standard-2
   client-1:
     roles:
-      - client
-      - permittedclient
-    platform:   el-7-x86_64
-    box:        generic/oracle7
-    hypervisor: <%= hypervisor %>
+    - client
+    - permittedclient
+    platform: el-7-x86_64
+    box: generic/oracle7
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
     vagrant_memsize: 192
+    family: sicura-image-build/oracle-linux-7
+    gce_machine_type: n1-standard-2
   client-2:
     roles:
-      - client
-      - unknownclient
-      - logdest
-      - ldapserver
-    platform:   el-7-x86_64
-    box:        generic/oracle7
-    hypervisor: <%= hypervisor %>
+    - client
+    - unknownclient
+    - logdest
+    - ldapserver
+    platform: el-7-x86_64
+    box: generic/oracle7
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
     vagrant_memsize: 192
+    family: sicura-image-build/oracle-linux-7
+    gce_machine_type: n1-standard-2
 CONFIG:
   log_level: verbose
-  type:      aio
+  type: aio
   run_in_parallel:
-    - install
-    - config
+  - install
+  - config
   ssh:
     keepalive: true
     keepalive_interval: 10
     keepalive_maxcount: 60
-<% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
-  puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
-<% end -%>
-  ## vb_gui: true
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet7') %>"

--- a/spec/acceptance/nodesets/oel-8-x86_64.yml
+++ b/spec/acceptance/nodesets/oel-8-x86_64.yml
@@ -1,78 +1,47 @@
-<%
-  if ENV['BEAKER_HYPERVISOR']
-    hypervisor = ENV['BEAKER_HYPERVISOR']
-  else
-    hypervisor = 'vagrant'
-  end
--%>
 ---
 HOSTS:
   server:
     roles:
-      - server
-      - default
-      - master
-    platform:   el-8-x86_64
-    box:        generic/oracle8
-    hypervisor: <%= hypervisor %>
+    - server
+    - default
+    - master
+    platform: el-8-x86_64
+    box: generic/oracle8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
     vagrant_memsize: 4096
     vagrant_cpus: 4
-#-------------------------------------------------------------------------------
-# If you want to use a web browser to manually inspect the SUT GitLab server
-# during any of the tests, uncomment the section below and add your host's
-# (non-local) IP address to the `TRUSTED_NETS` environment variable before
-# running beaker.
-#
-# See README.md for more details and environment variables
-#-------------------------------------------------------------------------------
-#    forwarded_ports:
-#      nginx_http:
-#        from: 8080
-#        to: 80
-#        from_ip: '127.0.0.1'
-#        to_ip: '0.0.0.0'
-#      nginx_https:
-#        from: 8443
-#        to: 443
-#        from_ip: '127.0.0.1'
-#        to_ip: '0.0.0.0'
-#      nginx_777:
-#        from: 8777
-#        to: 777
-#        from_ip: '127.0.0.1'
-#        to_ip: '0.0.0.0'
-#-------------------------------------------------------------------------------
+    family: sicura-image-build/oracle-linux-8
+    gce_machine_type: n1-standard-2
   client-1:
     roles:
-      - client
-      - permittedclient
-    platform:   el-8-x86_64
-    box:        generic/oracle8
-    hypervisor: <%= hypervisor %>
+    - client
+    - permittedclient
+    platform: el-8-x86_64
+    box: generic/oracle8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
     vagrant_memsize: 256
-
+    family: sicura-image-build/oracle-linux-8
+    gce_machine_type: n1-standard-2
   client-2:
     roles:
-      - client
-      - unknownclient
-      - logdest
-      - ldapserver
-    platform:   el-8-x86_64
-    box:        generic/oracle8
-    hypervisor: <%= hypervisor %>
+    - client
+    - unknownclient
+    - logdest
+    - ldapserver
+    platform: el-8-x86_64
+    box: generic/oracle8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
     vagrant_memsize: 2048
-
+    family: sicura-image-build/oracle-linux-8
+    gce_machine_type: n1-standard-2
 CONFIG:
   log_level: verbose
-  type:      aio
+  type: aio
   run_in_parallel:
-    - install
-    - config
+  - install
+  - config
   ssh:
     keepalive: true
     keepalive_interval: 10
     keepalive_maxcount: 60
-<% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
-  puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
-<% end -%>
-  ## vb_gui: true
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet7') %>"


### PR DESCRIPTION
This patch moves puppet 6 refs to 7, puppet 7 refs to 8. Then we manually
update all spec nodesets to point to sicura oel boxes.

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.