### PR TITLE
[puppetsync] Update metadata upper bounds for puppet-nsswitch, puppet-gitlab, puppet-snmp, simp-pam, and simp-useradd

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Feb 07 2024 Steven Pritchard <steve@sicura.us> - 0.12.0
+- [puppetsync] Add EL9 support
+
 * Mon Oct 23 2023 Steven Pritchard <steve@sicura.us> - 0.11.0
 - [puppetsync] Add EL9 support
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
-* Wed Feb 07 2024 Steven Pritchard <steve@sicura.us> - 0.12.0
-- [puppetsync] Add EL9 support
+* Wed Feb 07 2024 Mike Riddle <mike@sicura.us> - 0.12.0
+- [puppetsync] Update metadata upper bounds for puppet-nsswitch, puppet-gitlab, puppet-snmp, simp-pam, and simp-useradd
 
 * Mon Oct 23 2023 Steven Pritchard <steve@sicura.us> - 0.11.0
 - [puppetsync] Add EL9 support

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_gitlab",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "author": "SIMP Team",
   "summary": "SIMP profiles for GitLab",
   "license": "Apache-2.0",
@@ -25,7 +25,7 @@
     },
     {
       "name": "puppet/gitlab",
-      "version_requirement": ">= 6.0.1 < 9.0.0"
+      "version_requirement": ">= 6.0.1 < 10.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
@@ -37,7 +37,7 @@
     },
     {
       "name": "simp/pam",
-      "version_requirement": ">= 6.8.3 < 7.0.0"
+      "version_requirement": ">= 6.8.3 < 8.0.0"
     },
     {
       "name": "simp/pki",


### PR DESCRIPTION
The patch enforces a standardized asset baseline using
simp/puppetsync, and may also apply other updates to
ensure conformity.